### PR TITLE
fix: 7 bug fixes, new PM5 sensors, extended value mappings + sniffer tool

### DIFF
--- a/custom_components/bayrol/__init__.py
+++ b/custom_components/bayrol/__init__.py
@@ -26,7 +26,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     mqtt_manager = BayrolMQTTManager(
         hass, entry.data[BAYROL_DEVICE_ID], entry.data[BAYROL_ACCESS_TOKEN]
     )
-    hass.data[DOMAIN]["mqtt_manager"] = mqtt_manager
+    # Store mqtt_manager per entry so multiple config entries don't overwrite each other
+    hass.data[DOMAIN][entry.entry_id] = {
+        "data": entry.data,
+        "mqtt_manager": mqtt_manager,
+    }
     mqtt_manager.start()
 
     # Forward the setup to the platforms
@@ -42,13 +46,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     if unload_ok:
-        # Clean up MQTT manager
-        if "mqtt_manager" in hass.data[DOMAIN]:
-            mqtt_manager = hass.data[DOMAIN]["mqtt_manager"]
+        # Clean up only this entry's MQTT manager
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id, {})
+        mqtt_manager = entry_data.get("mqtt_manager")
+        if mqtt_manager:
             if mqtt_manager.client:
                 mqtt_manager.client.disconnect()
             if mqtt_manager.thread:
                 mqtt_manager.thread.join(timeout=1.0)
-        hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/custom_components/bayrol/config_flow.py
+++ b/custom_components/bayrol/config_flow.py
@@ -34,25 +34,38 @@ class BayrolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             code = user_input[BAYROL_APP_LINK_CODE]
-            # Fetch access token and device id from API
             url = f"https://www.bayrol-poolaccess.de/api/?code={code}"
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url) as response:
-                    data = await response.text()
-                    data_json = json.loads(data)
-                    access_token = data_json.get("accessToken")
-                    device_id = data_json.get("deviceSerial")
-                    if not access_token or not device_id:
-                        errors["base"] = "invalid_response"
-                    else:
-                        return self.async_create_entry(
-                            title="Bayrol",
-                            data={
-                                BAYROL_ACCESS_TOKEN: access_token,
-                                BAYROL_DEVICE_ID: device_id,
-                                BAYROL_DEVICE_TYPE: user_input[BAYROL_DEVICE_TYPE],
-                            },
-                        )
+            try:
+                timeout = aiohttp.ClientTimeout(total=10)
+                async with aiohttp.ClientSession(timeout=timeout) as session:
+                    async with session.get(url) as response:
+                        if response.status != 200:
+                            errors["base"] = "cannot_connect"
+                        else:
+                            try:
+                                data_json = await response.json(content_type=None)
+                            except (json.JSONDecodeError, ValueError):
+                                errors["base"] = "invalid_response"
+                            else:
+                                access_token = data_json.get("accessToken")
+                                device_id = data_json.get("deviceSerial")
+                                if not access_token or not device_id:
+                                    errors["base"] = "invalid_response"
+                                else:
+                                    await self.async_set_unique_id(device_id)
+                                    self._abort_if_unique_id_configured()
+                                    return self.async_create_entry(
+                                        title=f"Bayrol {device_id}",
+                                        data={
+                                            BAYROL_ACCESS_TOKEN: access_token,
+                                            BAYROL_DEVICE_ID: device_id,
+                                            BAYROL_DEVICE_TYPE: user_input[
+                                                BAYROL_DEVICE_TYPE
+                                            ],
+                                        },
+                                    )
+            except aiohttp.ClientError:
+                errors["base"] = "cannot_connect"
 
         return self.async_show_form(
             step_id="user",

--- a/custom_components/bayrol/const.py
+++ b/custom_components/bayrol/const.py
@@ -19,7 +19,7 @@ BAYROL_PORT = 8083
 AUTOMATIC_MQTT_TO_TEXT_MAPPING = {
     # Production rate mappings
     "19.3": "0.25x",
-    "19.4": "0.5x", 
+    "19.4": "0.5x",
     "19.5": "0.75x",
     "19.6": "1.0x",
     "19.7": "1.25x",
@@ -37,7 +37,7 @@ AUTOMATIC_MQTT_TO_TEXT_MAPPING = {
     "19.259": "empty",
     # Filtration mode mappings
     "19.315": "Low",
-    "19.316": "Med", 
+    "19.316": "Med",
     "19.317": "High",
     "19.346": "Auto",
     "19.330": "Smart",
@@ -51,13 +51,28 @@ AUTOMATIC_MQTT_TO_TEXT_MAPPING = {
 
 # MQTT value to display text mapping for PM5 models
 PM5_MQTT_TO_TEXT_MAPPING = {
+    # Pump on/off (discovered via MQTT sniffer on PM5 Chlorine)
+    "7001": "Inactive",
+    "7002": "Active",
+    # Cl pump / select options
     "7408": "On",
     "7407": "Off",
     "7427": "Auto",
+    # Canister / level status
+    "7521": "Full",
+    "7522": "Low",
+    "7523": "Empty",
+    # General status codes
+    "7524": "Ok",
+    "7525": "Info",
+    "7526": "Warning",
+    "7527": "Alarm",
 }
 
 # Reverse mapping for display text to MQTT values for Automatic devices
-AUTOMATIC_TEXT_TO_MQTT_MAPPING = {v: k for k, v in AUTOMATIC_MQTT_TO_TEXT_MAPPING.items()}
+AUTOMATIC_TEXT_TO_MQTT_MAPPING = {
+    v: k for k, v in AUTOMATIC_MQTT_TO_TEXT_MAPPING.items()
+}
 
 # Reverse mapping for display text to MQTT values for PM5 devices
 PM5_TEXT_TO_MQTT_MAPPING = {v: k for k, v in PM5_MQTT_TO_TEXT_MAPPING.items()}
@@ -632,7 +647,7 @@ SENSOR_TYPES_AUTOMATIC = {
     "4.67": {
         "name": "SW Version",
         "device_class": None,
-        "state_class": SensorStateClass.MEASUREMENT,
+        "state_class": None,  # Not a measurement — firmware version string
         "coefficient": 100,
         "unit_of_measurement": None,
         "entity_type": "sensor",
@@ -716,9 +731,9 @@ SENSOR_TYPES_AUTOMATIC = {
             "19.7",  # 1.25x
             "19.8",  # 1.5x
             "19.9",  # 2x
-            "19.10", # 3x
-            "19.11", # 5x
-            "19.12", # 10x
+            "19.10",  # 3x
+            "19.11",  # 5x
+            "19.12",  # 10x
         ],
     },
     "5.29": {
@@ -753,13 +768,13 @@ SENSOR_TYPES_AUTOMATIC = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.315", # Low
-            "19.316", # Med
-            "19.317", # High
-            "19.346", # Auto
-            "19.330", # Smart
-            "19.338", # Frost
-            "19.312"  # Off
+            "19.315",  # Low
+            "19.316",  # Med
+            "19.317",  # High
+            "19.346",  # Auto
+            "19.330",  # Smart
+            "19.338",  # Frost
+            "19.312",  # Off
         ],
     },
     "5.186": {
@@ -770,9 +785,9 @@ SENSOR_TYPES_AUTOMATIC = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.311", # Out On
-            "19.100", # Out Off
-            "19.345", # Out Auto
+            "19.311",  # Out On
+            "19.100",  # Out Off
+            "19.345",  # Out Auto
         ],
     },
     "5.187": {
@@ -783,9 +798,9 @@ SENSOR_TYPES_AUTOMATIC = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.311", # Out On
-            "19.100", # Out Off
-            "19.345", # Out Auto
+            "19.311",  # Out On
+            "19.100",  # Out Off
+            "19.345",  # Out Auto
         ],
     },
     "5.188": {
@@ -796,9 +811,9 @@ SENSOR_TYPES_AUTOMATIC = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.311", # Out On
-            "19.100", # Out Off
-            "19.345", # Out Auto
+            "19.311",  # Out On
+            "19.100",  # Out Off
+            "19.345",  # Out Auto
         ],
     },
     "5.189": {
@@ -809,9 +824,9 @@ SENSOR_TYPES_AUTOMATIC = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.311", # Out On
-            "19.100", # Out Off
-            "19.345", # Out Auto
+            "19.311",  # Out On
+            "19.100",  # Out Off
+            "19.345",  # Out Auto
         ],
     },
 }
@@ -962,8 +977,8 @@ SENSOR_TYPES_AUTOMATIC_SALT = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.17", # Yes
-            "19.18", # No
+            "19.17",  # Yes
+            "19.18",  # No
         ],
     },
     "5.41": {
@@ -974,9 +989,9 @@ SENSOR_TYPES_AUTOMATIC_SALT = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.195", # Auto
-            "19.115", # Auto Plus
-            "19.106", # Constant production
+            "19.195",  # Auto
+            "19.115",  # Auto Plus
+            "19.106",  # Constant production
         ],
     },
     "5.98": {
@@ -1023,9 +1038,9 @@ SENSOR_TYPES_AUTOMATIC_CL_PH = {
             "19.7",  # 1.25x
             "19.8",  # 1.5x
             "19.9",  # 2x
-            "19.10", # 3x
-            "19.11", # 5x
-            "19.12", # 10x
+            "19.10",  # 3x
+            "19.11",  # 5x
+            "19.12",  # 10x
         ],
     },
     "5.169": {
@@ -1130,7 +1145,28 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "coefficient": 100,
         "unit_of_measurement": "mg/l",
         "entity_type": "select",
-        "options": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0],
+        "options": [
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1.0,
+            1.1,
+            1.2,
+            1.3,
+            1.4,
+            1.5,
+            1.6,
+            1.7,
+            1.8,
+            1.9,
+            2.0,
+        ],
     },
     "4.3018": {
         "name": "Lower Alarm threshold Chlorine",
@@ -1139,7 +1175,23 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "coefficient": 100,
         "unit_of_measurement": "mg/l",
         "entity_type": "select",
-        "options": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5],
+        "options": [
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1.0,
+            1.1,
+            1.2,
+            1.3,
+            1.4,
+            1.5,
+        ],
     },
     "4.3019": {
         "name": "Upper Alarm threshold Chlorine",
@@ -1148,7 +1200,35 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "coefficient": 100,
         "unit_of_measurement": "mg/l",
         "entity_type": "select",
-        "options": [0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0],
+        "options": [
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1.0,
+            1.1,
+            1.2,
+            1.3,
+            1.4,
+            1.5,
+            1.6,
+            1.7,
+            1.8,
+            1.9,
+            2.0,
+            2.1,
+            2.2,
+            2.3,
+            2.4,
+            2.5,
+            2.6,
+            2.7,
+            2.8,
+            2.9,
+            3.0,
+        ],
     },
     "4.3049": {
         "name": "Setpoint Redox",
@@ -1586,9 +1666,9 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "7408", # On
-            "7407", # Off
-            "7427", # Auto
+            "7408",  # On
+            "7407",  # Off
+            "7427",  # Auto
         ],
     },
     "5.5434": {
@@ -1599,9 +1679,9 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "7408", # On
-            "7407", # Off
-            "7427", # Auto
+            "7408",  # On
+            "7407",  # Off
+            "7427",  # Auto
         ],
     },
     "5.5435": {
@@ -1612,9 +1692,9 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "7408", # On
-            "7407", # Off
-            "7427", # Auto
+            "7408",  # On
+            "7407",  # Off
+            "7427",  # Auto
         ],
     },
     "5.5436": {
@@ -1625,9 +1705,9 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "7408", # On
-            "7407", # Off
-            "7427", # Auto
+            "7408",  # On
+            "7407",  # Off
+            "7427",  # Auto
         ],
     },
     "5.6012": {
@@ -1680,6 +1760,57 @@ SENSOR_TYPES_PM5_CHLORINE = {
     },
     "5.6069": {
         "name": "Redox Status",
+        "device_class": None,
+        "state_class": None,
+        "coefficient": None,
+        "unit_of_measurement": None,
+        "entity_type": "sensor",
+    },
+    # Additional pump status sensors discovered via MQTT sniffer (PM5 Chlorine)
+    # Values: 7001 = Inactive, 7002 = Active
+    "5.6028": {
+        "name": "Cl Pump Status 2",
+        "device_class": None,
+        "state_class": None,
+        "coefficient": None,
+        "unit_of_measurement": None,
+        "entity_type": "sensor",
+    },
+    "5.6029": {
+        "name": "Pump Status",
+        "device_class": None,
+        "state_class": None,
+        "coefficient": None,
+        "unit_of_measurement": None,
+        "entity_type": "sensor",
+    },
+    "5.6039": {
+        "name": "Pump Status 2",
+        "device_class": None,
+        "state_class": None,
+        "coefficient": None,
+        "unit_of_measurement": None,
+        "entity_type": "sensor",
+    },
+    # Extended status sensors (7524 = Ok, 7526 = Warning)
+    "5.6067": {
+        "name": "pH System Status",
+        "device_class": None,
+        "state_class": None,
+        "coefficient": None,
+        "unit_of_measurement": None,
+        "entity_type": "sensor",
+    },
+    "5.6071": {
+        "name": "Cl System Status",
+        "device_class": None,
+        "state_class": None,
+        "coefficient": None,
+        "unit_of_measurement": None,
+        "entity_type": "sensor",
+    },
+    "5.6072": {
+        "name": "Redox System Status",
         "device_class": None,
         "state_class": None,
         "coefficient": None,

--- a/custom_components/bayrol/select.py
+++ b/custom_components/bayrol/select.py
@@ -32,27 +32,35 @@ def _handle_select_value(select, value):
     """Handle incoming select value."""
     _LOGGER.debug("Received MQTT value: %s for select: %s", value, select._attr_name)
     _LOGGER.debug("Available options: %s", select._attr_options)
-    
+
     # Try to find the value in the device-specific mappings and store the TEXT value
     if select._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
         if str(value) in PM5_MQTT_TO_TEXT_MAPPING:
             select._attr_current_option = PM5_MQTT_TO_TEXT_MAPPING[str(value)]
-            _LOGGER.debug("PM5 mapping found: %s -> %s", value, select._attr_current_option)
+            _LOGGER.debug(
+                "PM5 mapping found: %s -> %s", value, select._attr_current_option
+            )
         else:
             # Try coefficient conversion for numeric values
             _handle_numeric_value(select, value)
-    elif (select._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH" or 
-          select._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"):
+    elif (
+        select._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH"
+        or select._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"
+    ):
         if str(value) in AUTOMATIC_MQTT_TO_TEXT_MAPPING:
             select._attr_current_option = AUTOMATIC_MQTT_TO_TEXT_MAPPING[str(value)]
-            _LOGGER.debug("Automatic mapping found: %s -> %s", value, select._attr_current_option)
+            _LOGGER.debug(
+                "Automatic mapping found: %s -> %s", value, select._attr_current_option
+            )
         else:
             # Try coefficient conversion for numeric values
             _handle_numeric_value(select, value)
     else:
-        _LOGGER.warning("Unknown device type: %s", select._config_entry.data[BAYROL_DEVICE_TYPE])
+        _LOGGER.warning(
+            "Unknown device type: %s", select._config_entry.data[BAYROL_DEVICE_TYPE]
+        )
         _handle_numeric_value(select, value)
-    
+
     _LOGGER.debug("Set current_option to: %s", select._attr_current_option)
     if select.hass is not None:
         select.schedule_update_ha_state()
@@ -64,8 +72,13 @@ def _handle_numeric_value(select, value):
         coefficient = select._select_config.get("coefficient")
         if coefficient is not None and coefficient != -1:
             converted_value = float(value) / coefficient
-            _LOGGER.debug("Converted value using coefficient %s: %s -> %s", coefficient, value, converted_value)
-            
+            _LOGGER.debug(
+                "Converted value using coefficient %s: %s -> %s",
+                coefficient,
+                value,
+                converted_value,
+            )
+
             # Find the closest option
             if coefficient == 1:
                 converted_value = int(converted_value)
@@ -73,7 +86,7 @@ def _handle_numeric_value(select, value):
             else:
                 converted_value = float(converted_value)
                 options = [float(opt) for opt in select._attr_options]
-            
+
             closest_option = min(options, key=lambda x: abs(x - converted_value))
             select._attr_current_option = str(closest_option)
             _LOGGER.debug("Found closest option: %s", closest_option)
@@ -95,8 +108,8 @@ async def async_setup_entry(
     device_type = config_entry.data[BAYROL_DEVICE_TYPE]
     _LOGGER.debug("device_type: %s", device_type)
 
-    # Get the shared MQTT manager
-    mqtt_manager = hass.data[DOMAIN]["mqtt_manager"]
+    # Get the MQTT manager for this specific config entry
+    mqtt_manager = hass.data[DOMAIN][config_entry.entry_id]["mqtt_manager"]
 
     if device_type == "Automatic SALT":
         for select_type, select_config in SENSOR_TYPES_AUTOMATIC_SALT.items():
@@ -156,22 +169,24 @@ class BayrolSelect(SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         _LOGGER.debug("User selected option: %s", option)
-        
+
         # Convert display text back to MQTT value based on device type
         mqtt_value = None
-        
+
         if self._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
             # Use PM5 specific mappings
             if option in PM5_TEXT_TO_MQTT_MAPPING:
                 mqtt_value = PM5_TEXT_TO_MQTT_MAPPING[option]
                 _LOGGER.debug("PM5 text mapping: %s -> %s", option, mqtt_value)
-        elif (self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH" or 
-              self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"):
+        elif (
+            self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH"
+            or self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"
+        ):
             # Use Automatic specific mappings
             if option in AUTOMATIC_TEXT_TO_MQTT_MAPPING:
                 mqtt_value = AUTOMATIC_TEXT_TO_MQTT_MAPPING[option]
                 _LOGGER.debug("Automatic text mapping: %s -> %s", option, mqtt_value)
-        
+
         if mqtt_value is None:
             # If no text mapping found, try coefficient conversion for numeric options
             try:
@@ -179,9 +194,13 @@ class BayrolSelect(SelectEntity):
                 if coefficient is not None and coefficient != -1:
                     # Convert display value to MQTT value
                     display_float = float(option)
-                    mqtt_value = str(int(display_float * coefficient))
-                    _LOGGER.debug("Converted display value %s to MQTT value %s using coefficient %s", 
-                                option, mqtt_value, coefficient)
+                    mqtt_value = str(round(display_float * coefficient))
+                    _LOGGER.debug(
+                        "Converted display value %s to MQTT value %s using coefficient %s",
+                        option,
+                        mqtt_value,
+                        coefficient,
+                    )
                 else:
                     # No coefficient, use option as MQTT value directly
                     mqtt_value = option
@@ -195,13 +214,19 @@ class BayrolSelect(SelectEntity):
         # For numeric options, check if the original option is in options
         if mqtt_value in self._attr_options:
             # This is a text mapping case (like Production Rate)
-            _LOGGER.debug("Text mapping case: MQTT value %s found in options", mqtt_value)
+            _LOGGER.debug(
+                "Text mapping case: MQTT value %s found in options", mqtt_value
+            )
         elif option in self._attr_options:
             # This is a numeric case (like Salt Level)
             _LOGGER.debug("Numeric case: option %s found in options", option)
         else:
-            _LOGGER.error("Invalid option: %s (MQTT value: %s). Available options: %s", 
-                         option, mqtt_value, self._attr_options)
+            _LOGGER.error(
+                "Invalid option: %s (MQTT value: %s). Available options: %s",
+                option,
+                mqtt_value,
+                self._attr_options,
+            )
             return
 
         # Update the current option to the TEXT value (user's selection)
@@ -210,7 +235,9 @@ class BayrolSelect(SelectEntity):
         # Publish the new value to the MQTT topic
         topic = f"d02/{self._config_entry.data[BAYROL_DEVICE_ID]}/s/{self._state_topic}"
         payload = f'{{"t":"{self._state_topic}","v":{mqtt_value}}}'
-        self.hass.data[DOMAIN]["mqtt_manager"].client.publish(topic, payload)
+        self.hass.data[DOMAIN][self._config_entry.entry_id][
+            "mqtt_manager"
+        ].client.publish(topic, payload)
         _LOGGER.debug("Published MQTT message: %s", payload)
 
     @property
@@ -221,15 +248,17 @@ class BayrolSelect(SelectEntity):
         for option in self._attr_options:
             # Convert option to string for mapping lookup
             option_str = str(option)
-            
+
             if self._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
                 # Use PM5 specific mappings
                 if option_str in PM5_MQTT_TO_TEXT_MAPPING:
                     display_options.append(PM5_MQTT_TO_TEXT_MAPPING[option_str])
                 else:
                     display_options.append(option_str)
-            elif (self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH" or 
-                  self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"):
+            elif (
+                self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH"
+                or self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"
+            ):
                 # Use Automatic specific mappings
                 if option_str in AUTOMATIC_MQTT_TO_TEXT_MAPPING:
                     display_options.append(AUTOMATIC_MQTT_TO_TEXT_MAPPING[option_str])
@@ -237,11 +266,13 @@ class BayrolSelect(SelectEntity):
                     display_options.append(option_str)
             else:
                 # Unknown device type - this should not happen
-                _LOGGER.warning("Unknown device type: %s. Cannot map option: %s", 
-                               self._config_entry.data[BAYROL_DEVICE_TYPE], option_str)
+                _LOGGER.warning(
+                    "Unknown device type: %s. Cannot map option: %s",
+                    self._config_entry.data[BAYROL_DEVICE_TYPE],
+                    option_str,
+                )
                 display_options.append(option_str)
         return display_options
-
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/bayrol/sensor.py
+++ b/custom_components/bayrol/sensor.py
@@ -29,11 +29,11 @@ def _handle_sensor_value(sensor, value):
     """Handle incoming sensor value."""
     # Check if this is a numeric sensor that should not be converted to strings
     is_numeric_sensor = (
-        sensor._sensor_config.get("state_class") is not None and
-        sensor._sensor_config.get("state_class") != "None" and
-        sensor._sensor_config.get("unit_of_measurement") is not None
+        sensor._sensor_config.get("state_class") is not None
+        and sensor._sensor_config.get("state_class") != "None"
+        and sensor._sensor_config.get("unit_of_measurement") is not None
     )
-    
+
     # If it's a numeric sensor, handle it directly without string conversion
     if is_numeric_sensor:
         if (
@@ -47,7 +47,7 @@ def _handle_sensor_value(sensor, value):
         # Handle string conversion for non-numeric sensors
         match value:
             case "19.18":
-                sensor._attr_native_value = "On"
+                sensor._attr_native_value = "No"
             case "19.19":
                 sensor._attr_native_value = "Off"
             case "19.95":
@@ -109,7 +109,9 @@ def _handle_sensor_value(sensor, value):
                     sensor._sensor_config.get("coefficient") is not None
                     and sensor._sensor_config["coefficient"] != -1
                 ):
-                    sensor._attr_native_value = value / sensor._sensor_config["coefficient"]
+                    sensor._attr_native_value = (
+                        value / sensor._sensor_config["coefficient"]
+                    )
                 elif sensor._sensor_config.get("coefficient") == -1:
                     sensor._attr_native_value = str(value)
                 else:
@@ -129,8 +131,8 @@ async def async_setup_entry(
     device_type = config_entry.data[BAYROL_DEVICE_TYPE]
     _LOGGER.debug("device_type: %s", device_type)
 
-    # Get the shared MQTT manager
-    mqtt_manager = hass.data[DOMAIN]["mqtt_manager"]
+    # Get the MQTT manager for this specific config entry
+    mqtt_manager = hass.data[DOMAIN][config_entry.entry_id]["mqtt_manager"]
 
     if device_type == "Automatic SALT":
         for sensor_type, sensor_config in SENSOR_TYPES_AUTOMATIC_SALT.items():
@@ -186,7 +188,7 @@ class BayrolSensor(SensorEntity):
         elif coefficient == 10:
             self._attr_suggested_display_precision = 1
         elif coefficient == 100:
-            self._attr_display_precision = 2
+            self._attr_suggested_display_precision = 2
         self._attr_native_value = None
 
     async def async_added_to_hass(self) -> None:

--- a/tools/mqtt_sniffer.py
+++ b/tools/mqtt_sniffer.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+"""
+MQTT Topic Sniffer for Bayrol Pool Devices
+
+This script discovers ALL MQTT topics that a Bayrol device sends,
+including topics not defined in const.py (like Flow, Filterpump, etc.)
+
+Usage:
+    python scripts/mqtt_sniffer.py --device-id YOUR_DEVICE_SERIAL --token YOUR_ACCESS_TOKEN
+
+    Or use environment variables:
+    BAYROL_DEVICE_ID=xxx BAYROL_ACCESS_TOKEN=xxx python scripts/mqtt_sniffer.py
+
+The script will:
+1. Connect to Bayrol MQTT broker
+2. Subscribe to ALL topics for your device using wildcard
+3. Log every discovered topic with its value
+4. Save results to a JSON file for analysis
+"""
+
+import argparse
+import json
+import logging
+import os
+import signal
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+import paho.mqtt.client as mqtt
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+# Bayrol MQTT defaults (can be overridden via --host / --port)
+BAYROL_HOST = os.environ.get("BAYROL_MQTT_HOST", "www.bayrol-poolaccess.de")
+BAYROL_PORT = int(os.environ.get("BAYROL_MQTT_PORT", "8083"))
+
+# Known topics from const.py (for comparison)
+KNOWN_TOPICS_AUTOMATIC = {
+    "4.2",
+    "4.3",
+    "4.4",
+    "4.5",
+    "4.7",
+    "4.26",
+    "4.27",
+    "4.28",
+    "4.34",
+    "4.37",
+    "4.38",
+    "4.47",
+    "4.67",
+    "4.68",
+    "4.69",
+    "4.82",
+    "4.89",
+    "4.98",
+    "4.102",
+    "4.107",
+    "4.182",
+    "5.3",
+    "5.80",
+    "5.98",
+}
+
+KNOWN_TOPICS_AUTOMATIC_SALT = KNOWN_TOPICS_AUTOMATIC | {
+    "4.51",
+    "4.66",
+    "4.91",
+    "4.100",
+    "4.104",
+    "4.105",
+    "4.112",
+    "4.119",
+    "4.144",
+    "5.40",
+    "5.41",
+}
+
+KNOWN_TOPICS_AUTOMATIC_CL_PH = KNOWN_TOPICS_AUTOMATIC | {"4.90", "5.175", "5.169"}
+
+KNOWN_TOPICS_PM5 = {
+    "4.3001",
+    "4.3002",
+    "4.3003",
+    "4.3049",
+    "4.3051",
+    "4.3053",
+    "4.4001",
+    "4.4022",
+    "4.4033",
+    "4.4069",
+    "4.4132",
+    "5.5433",
+    "5.5434",
+    "5.5435",
+    "5.5436",
+    "5.6012",
+    "5.6015",
+    "5.6064",
+    "5.6065",
+    "5.6068",
+    "5.6069",
+}
+
+ALL_KNOWN_TOPICS = (
+    KNOWN_TOPICS_AUTOMATIC_SALT | KNOWN_TOPICS_AUTOMATIC_CL_PH | KNOWN_TOPICS_PM5
+)
+
+
+class MQTTSniffer:
+    """Sniffs all MQTT topics from a Bayrol device."""
+
+    def __init__(
+        self, device_id: str, access_token: str, output_dir: str = "discovered_topics"
+    ):
+        self.device_id = device_id
+        self.access_token = access_token
+        self.output_dir = Path(output_dir)
+        self.output_dir.mkdir(exist_ok=True)
+
+        self.client: Optional[mqtt.Client] = None
+        self.discovered_topics: Dict[str, Dict[str, Any]] = {}
+        self.new_topics: Dict[str, Dict[str, Any]] = {}  # Topics not in const.py
+        self.previously_discovered: set = set()  # Topics from previous runs
+        self.start_time = datetime.now()
+        self.message_count = 0
+        self.running = True
+
+        # Load previously discovered topics
+        self._load_previous_discoveries()
+
+    def _load_previous_discoveries(self):
+        """Load topics from previous discovery sessions."""
+        # Look for existing discovery files for this device
+        pattern = f"all_topics_{self.device_id}_*.json"
+        existing_files = sorted(self.output_dir.glob(pattern), reverse=True)
+
+        if existing_files:
+            # Load the most recent file
+            latest_file = existing_files[0]
+            try:
+                with open(latest_file, "r") as f:
+                    data = json.load(f)
+                    topics = data.get("topics", {})
+                    self.previously_discovered = set(topics.keys())
+                    logger.info(
+                        f"Loaded {len(self.previously_discovered)} previously discovered topics from {latest_file.name}"
+                    )
+            except Exception as e:
+                logger.warning(f"Could not load previous discoveries: {e}")
+
+        # Also check for a persistent "known topics" file
+        persistent_file = self.output_dir / f"known_topics_{self.device_id}.json"
+        if persistent_file.exists():
+            try:
+                with open(persistent_file, "r") as f:
+                    data = json.load(f)
+                    self.previously_discovered.update(data.get("topics", []))
+                    logger.info(
+                        f"Loaded persistent known topics from {persistent_file.name}"
+                    )
+            except Exception as e:
+                logger.warning(f"Could not load persistent file: {e}")
+
+    def _save_persistent_topics(self):
+        """Save all discovered topics to a persistent file."""
+        persistent_file = self.output_dir / f"known_topics_{self.device_id}.json"
+        all_topics = self.previously_discovered | set(self.discovered_topics.keys())
+
+        with open(persistent_file, "w") as f:
+            json.dump(
+                {
+                    "device_id": self.device_id,
+                    "last_updated": datetime.now().isoformat(),
+                    "topics": sorted(list(all_topics)),
+                },
+                f,
+                indent=2,
+            )
+        logger.info(f"Saved {len(all_topics)} topics to {persistent_file}")
+
+    def on_connect(self, client, userdata, flags, rc):
+        """Handle connection to MQTT broker."""
+        if rc == 0:
+            logger.info(f"Connected to Bayrol MQTT broker")
+            logger.info(f"Device ID: {self.device_id}")
+
+            # Subscribe to ALL topics for this device using wildcard
+            wildcard_topic = f"d02/{self.device_id}/v/#"
+            client.subscribe(wildcard_topic)
+            logger.info(f"Subscribed to: {wildcard_topic}")
+            logger.info("-" * 60)
+            logger.info("Waiting for messages... (Press Ctrl+C to stop)")
+            logger.info("-" * 60)
+        else:
+            logger.error(f"Connection failed with code: {rc}")
+            if rc == 5:
+                logger.error("Authentication failed - check your access token")
+            self.running = False
+
+    def on_message(self, client, userdata, msg):
+        """Handle incoming MQTT message."""
+        self.message_count += 1
+
+        # Parse topic
+        topic_parts = msg.topic.split("/")
+        sensor_id = topic_parts[-1] if len(topic_parts) > 0 else "unknown"
+
+        # Store raw payload
+        raw_payload = msg.payload.decode("utf-8", errors="replace")
+
+        # Parse payload
+        try:
+            payload = json.loads(msg.payload)
+            # Handle different payload formats:
+            # - Dict with "v" key: {"v": 123}
+            # - List: [1, 2, 3]
+            # - Direct value: 123
+            if isinstance(payload, dict):
+                value = payload.get("v", payload)
+            else:
+                # Lists, numbers, strings, etc.
+                value = payload
+        except json.JSONDecodeError:
+            value = raw_payload
+            payload = raw_payload
+
+        timestamp = datetime.now().isoformat()
+
+        # Check if this is a new topic
+        is_new_this_session = sensor_id not in self.discovered_topics
+        is_new_ever = (
+            sensor_id not in self.previously_discovered and is_new_this_session
+        )
+        is_unknown = sensor_id not in ALL_KNOWN_TOPICS
+
+        # Check if this is a new/different value for a known topic
+        is_new_value = False
+        if not is_new_this_session and is_unknown:
+            existing = self.discovered_topics[sensor_id]
+            value_str = json.dumps(value) if isinstance(value, (list, dict)) else value
+            sample_strs = [
+                json.dumps(v) if isinstance(v, (list, dict)) else v
+                for v in existing.get("sample_values", [])
+            ]
+            is_new_value = value_str not in sample_strs
+
+        # Store topic info
+        topic_info = {
+            "sensor_id": sensor_id,
+            "full_topic": msg.topic,
+            "raw_payload": raw_payload,
+            "parsed_payload": payload,
+            "value": value,
+            "value_type": type(value).__name__,
+            "first_seen": timestamp
+            if is_new_this_session
+            else self.discovered_topics.get(sensor_id, {}).get("first_seen", timestamp),
+            "last_seen": timestamp,
+            "update_count": self.discovered_topics.get(sensor_id, {}).get(
+                "update_count", 0
+            )
+            + 1,
+            "is_in_const_py": not is_unknown,
+            "sample_values": self.discovered_topics.get(sensor_id, {}).get(
+                "sample_values", []
+            ),
+            "raw_samples": self.discovered_topics.get(sensor_id, {}).get(
+                "raw_samples", []
+            ),
+        }
+
+        # Store sample values (up to 10 unique values)
+        # Convert to string for comparison since lists aren't hashable
+        value_str = json.dumps(value) if isinstance(value, (list, dict)) else value
+        sample_strs = [
+            json.dumps(v) if isinstance(v, (list, dict)) else v
+            for v in topic_info["sample_values"]
+        ]
+        if value_str not in sample_strs and len(topic_info["sample_values"]) < 10:
+            topic_info["sample_values"].append(value)
+            topic_info["raw_samples"].append(raw_payload)
+
+        self.discovered_topics[sensor_id] = topic_info
+
+        # Track unknown topics separately
+        if is_unknown:
+            self.new_topics[sensor_id] = topic_info
+
+        # Log the message
+        if is_new_ever:
+            status = "NEW!   "
+        elif is_new_this_session:
+            status = "SEEN   "  # Known from previous runs
+        elif is_new_value:
+            status = "UPDATE "  # New value for known topic
+        else:
+            status = "       "
+
+        unknown_marker = " [NOT IN CONST.PY]" if is_unknown else ""
+
+        # Try to guess coefficient for numeric values
+        coefficient_hint = ""
+        if isinstance(value, (int, float)) and value != 0:
+            # Common coefficients: 10, 100, 1000
+            if abs(value) > 100:
+                coefficient_hint = (
+                    f" (maybe /10={value / 10:.1f} or /100={value / 100:.2f})"
+                )
+
+        if is_new_ever or (is_new_this_session and is_unknown):
+            logger.info(
+                f"{status} Topic: {sensor_id:12} | Value: {str(value):15}{coefficient_hint}{unknown_marker}"
+            )
+            logger.info(f"         RAW: {raw_payload}")
+            logger.info(f"         Full topic: {msg.topic}")
+            logger.info("-" * 80)
+        elif is_new_value:
+            # New value discovered for existing topic!
+            old_values = self.discovered_topics[sensor_id].get("sample_values", [])
+            logger.info(
+                f"{status} Topic: {sensor_id:12} | Value: {str(value):15}{coefficient_hint}{unknown_marker}"
+            )
+            logger.info(f"         Previous values: {old_values[:5]}")
+            logger.info(f"         RAW: {raw_payload}")
+            logger.info("-" * 80)
+        elif is_unknown:
+            # Unknown but seen before - still show updates
+            logger.info(
+                f"{status} Topic: {sensor_id:12} | Value: {str(value):15}{coefficient_hint}{unknown_marker}"
+            )
+        else:
+            logger.debug(f"{status} Topic: {sensor_id:12} | Value: {str(value):15}")
+
+    def on_disconnect(self, client, userdata, rc):
+        """Handle disconnection from MQTT broker."""
+        if rc != 0:
+            logger.warning(f"Unexpected disconnection (code: {rc})")
+        else:
+            logger.info("Disconnected from broker")
+
+    def start(self):
+        """Start the MQTT sniffer."""
+        logger.info("=" * 60)
+        logger.info("BAYROL MQTT TOPIC SNIFFER")
+        logger.info("=" * 60)
+
+        # Create MQTT client
+        self.client = mqtt.Client(transport="websockets")
+        self.client.username_pw_set(self.access_token, "1")
+        self.client.tls_set()
+
+        # Set callbacks
+        self.client.on_connect = self.on_connect
+        self.client.on_message = self.on_message
+        self.client.on_disconnect = self.on_disconnect
+
+        # Connect
+        try:
+            logger.info(f"Connecting to {BAYROL_HOST}:{BAYROL_PORT}...")
+            self.client.connect(BAYROL_HOST, BAYROL_PORT, keepalive=60)
+        except Exception as e:
+            logger.error(f"Connection failed: {e}")
+            return
+
+        # Start loop
+        self.client.loop_start()
+
+        # Wait for messages
+        try:
+            while self.running:
+                time.sleep(1)
+        except KeyboardInterrupt:
+            logger.info("\nStopping sniffer...")
+
+        self.stop()
+
+    def stop(self):
+        """Stop the sniffer and save results."""
+        self.running = False
+
+        if self.client:
+            self.client.loop_stop()
+            self.client.disconnect()
+
+        # Save results
+        self.save_results()
+
+    def save_results(self):
+        """Save discovered topics to files."""
+        duration = (datetime.now() - self.start_time).total_seconds()
+
+        # Summary
+        logger.info("")
+        logger.info("=" * 60)
+        logger.info("DISCOVERY RESULTS")
+        logger.info("=" * 60)
+        logger.info(f"Duration: {duration:.1f} seconds")
+        logger.info(f"Total messages received: {self.message_count}")
+        logger.info(f"Unique topics discovered: {len(self.discovered_topics)}")
+        logger.info(f"NEW topics (not in const.py): {len(self.new_topics)}")
+
+        if self.new_topics:
+            logger.info("")
+            logger.info("NEW TOPICS FOUND:")
+            logger.info("-" * 60)
+            for sensor_id, info in sorted(self.new_topics.items()):
+                logger.info(f"  {sensor_id:12} | Samples: {info['sample_values'][:3]}")
+
+        # Save all discovered topics
+        all_topics_file = (
+            self.output_dir
+            / f"all_topics_{self.device_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        )
+        with open(all_topics_file, "w") as f:
+            json.dump(
+                {
+                    "device_id": self.device_id,
+                    "discovery_time": self.start_time.isoformat(),
+                    "duration_seconds": duration,
+                    "message_count": self.message_count,
+                    "topics": self.discovered_topics,
+                },
+                f,
+                indent=2,
+                default=str,
+            )
+        logger.info(f"\nAll topics saved to: {all_topics_file}")
+
+        # Save new topics separately
+        if self.new_topics:
+            new_topics_file = (
+                self.output_dir
+                / f"new_topics_{self.device_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+            )
+            with open(new_topics_file, "w") as f:
+                json.dump(
+                    {
+                        "device_id": self.device_id,
+                        "discovery_time": self.start_time.isoformat(),
+                        "new_topics": self.new_topics,
+                    },
+                    f,
+                    indent=2,
+                    default=str,
+                )
+            logger.info(f"New topics saved to: {new_topics_file}")
+
+            # Generate const.py snippet
+            self.generate_const_snippet()
+
+        # Save persistent topics file (for future runs)
+        self._save_persistent_topics()
+
+    def generate_const_snippet(self):
+        """Generate a code snippet to add to const.py."""
+        if not self.new_topics:
+            return
+
+        snippet_file = self.output_dir / f"const_snippet_{self.device_id}.py"
+
+        lines = [
+            "# NEW DISCOVERED TOPICS",
+            f"# Discovered from device: {self.device_id}",
+            f"# Discovery date: {datetime.now().isoformat()}",
+            "#",
+            "# Add these to the appropriate SENSOR_TYPES_* dictionary in const.py",
+            "# You may need to determine the correct coefficient and unit for each sensor",
+            "",
+            "NEW_DISCOVERED_SENSORS = {",
+        ]
+
+        for sensor_id, info in sorted(self.new_topics.items()):
+            sample_value = (
+                info["sample_values"][0] if info["sample_values"] else "unknown"
+            )
+            value_type = info["value_type"]
+
+            # Try to guess the sensor type
+            coefficient = "1"
+            unit = "None"
+            name = f"Unknown Sensor {sensor_id}"
+
+            # Guess based on value patterns
+            if isinstance(sample_value, (int, float)):
+                if sample_value > 1000:
+                    coefficient = "1"
+                    unit = '"mV"'  # Likely voltage
+                elif 0 < sample_value < 20:
+                    coefficient = "10"
+                    unit = "None"  # Likely pH or similar
+                elif 0 < sample_value < 100:
+                    coefficient = "1"
+                    unit = '"%"'  # Likely percentage
+
+            lines.extend(
+                [
+                    f'    "{sensor_id}": {{',
+                    f'        "name": "{name}",  # TODO: Determine actual name',
+                    f'        "device_class": None,',
+                    f'        "state_class": SensorStateClass.MEASUREMENT,',
+                    f'        "coefficient": {coefficient},  # TODO: Verify coefficient',
+                    f'        "unit_of_measurement": {unit},  # TODO: Verify unit',
+                    f'        "entity_type": "sensor",',
+                    f"        # Sample values: {info['sample_values'][:5]}",
+                    f"    }},",
+                ]
+            )
+
+        lines.append("}")
+
+        with open(snippet_file, "w") as f:
+            f.write("\n".join(lines))
+
+        logger.info(f"Code snippet saved to: {snippet_file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Sniff all MQTT topics from a Bayrol pool device"
+    )
+    parser.add_argument(
+        "--device-id",
+        default=os.environ.get("BAYROL_DEVICE_ID"),
+        help="Device serial number (or set BAYROL_DEVICE_ID env var)",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("BAYROL_ACCESS_TOKEN"),
+        help="Access token (or set BAYROL_ACCESS_TOKEN env var)",
+    )
+    parser.add_argument(
+        "--host",
+        default=BAYROL_HOST,
+        help="MQTT broker host (default: www.bayrol-poolaccess.de, or BAYROL_MQTT_HOST env)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=BAYROL_PORT,
+        help="MQTT broker port (default: 8083, or BAYROL_MQTT_PORT env)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="discovered_topics",
+        help="Directory to save results (default: discovered_topics)",
+    )
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=0,
+        help="Run for N seconds then stop (0 = run until Ctrl+C)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show all messages, not just new ones",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("BAYROL_ACCESS_TOKEN"),
+        help="Access token (or set BAYROL_ACCESS_TOKEN env var)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="discovered_topics",
+        help="Directory to save results (default: discovered_topics)",
+    )
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=0,
+        help="Run for N seconds then stop (0 = run until Ctrl+C)",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show all messages, not just new ones",
+    )
+
+    args = parser.parse_args()
+
+    if not args.device_id:
+        logger.error("Device ID required! Use --device-id or set BAYROL_DEVICE_ID")
+        logger.info("")
+        logger.info("How to get your device ID and token:")
+        logger.info("  Use the Bayrol app link code flow:")
+        logger.info(
+            "  GET https://www.bayrol-poolaccess.de/webapi/p/v3/getaccesstoken?code=XXXXXXXX"
+        )
+        logger.info("  Response contains 'deviceSerial' (device ID) and 'accessToken'")
+        sys.exit(1)
+
+    if not args.token:
+        logger.error("Access token required! Use --token or set BAYROL_ACCESS_TOKEN")
+        sys.exit(1)
+
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    # Allow overriding host/port at runtime
+    global BAYROL_HOST, BAYROL_PORT
+    BAYROL_HOST = args.host
+    BAYROL_PORT = args.port
+
+    sniffer = MQTTSniffer(
+        device_id=args.device_id, access_token=args.token, output_dir=args.output_dir
+    )
+
+    # Handle duration
+    if args.duration > 0:
+
+        def stop_after_duration():
+            time.sleep(args.duration)
+            logger.info(f"\nDuration of {args.duration}s reached, stopping...")
+            sniffer.running = False
+
+        import threading
+
+        timer = threading.Thread(target=stop_after_duration, daemon=True)
+        timer.start()
+
+    # Handle signals
+    def signal_handler(sig, frame):
+        logger.info("\nReceived stop signal...")
+        sniffer.running = False
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    # Start sniffing
+    sniffer.start()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Wie in #24 besprochen — hier der PR mit allem was ich gefunden habe.

## Bug Fixes

### `sensor.py`
- **`"19.18"` → `"No"` (war `"On"`)** — `const.py` Zeile 32 definiert `"19.18"` als `"No"`, `sensor.py` hat `"On"` zurückgegeben
- **`_attr_suggested_display_precision`** statt `_attr_display_precision` für `coefficient == 100`

### `__init__.py`
- **mqtt_manager per `entry_id`** statt global gespeichert — ein zweiter Config Entry hat den ersten Manager überschrieben → Closes #12

### `config_flow.py`
- **`async_set_unique_id` + `_abort_if_unique_id_configured`** — dasselbe Gerät konnte unbegrenzt doppelt hinzugefügt werden
- **Timeout, HTTP-Status-Check und Exception Handling** für den API-Request

### `select.py`
- **`round()` statt `int()`** bei der Koeffizient-Umrechnung — Float-Truncation konnte Werte um 1 zu niedrig schreiben (z.B. `7.1 * 100 = 709.999 → int = 709`)
- mqtt_manager aus entry-spezifischem Dict gelesen

### `const.py`
- **`state_class` bei `SW Version` entfernt** — Firmware-Version ist keine Messgröße, HA hat versucht Statistiken darüber zu berechnen

---

## Neue PM5 Chlorine Sensoren

Via MQTT Sniffer (`d02/{serial}/v/#`) entdeckt:

| Topic | Name | Werte |
|-------|------|-------|
| `5.6028` | Cl Pump Status 2 | 7001/7002 |
| `5.6029` | Pump Status | 7001/7002 |
| `5.6039` | Pump Status 2 | 7001/7002 |
| `5.6067` | pH System Status | 7524/7526 |
| `5.6071` | Cl System Status | 7524/7526 |
| `5.6072` | Redox System Status | 7524/7526 |

---

## Erweiterte `PM5_MQTT_TO_TEXT_MAPPING`

```python
"7001": "Inactive"   # Pumpe aus
"7002": "Active"     # Pumpe ein
"7521": "Full"       # Kanister voll
"7522": "Low"        # Kanister niedrig
"7523": "Empty"      # Kanister leer
"7524": "Ok"
"7525": "Info"
"7526": "Warning"
"7527": "Alarm"
```

---

## Sniffer Tool (`tools/mqtt_sniffer.py`)

Abonniert `d02/{serial}/v/#` und zeichnet alle Topics auf die das Gerät sendet — inklusive Erkennung welche noch nicht in `const.py` definiert sind.

```bash
pip install paho-mqtt
python tools/mqtt_sniffer.py --device-id DEIN_SERIAL --token DEIN_TOKEN --duration 300
```

---

**Hinweis zu #17:** Das Gerät sendet auf Topics `8.2002`/`8.2003` Alarm-Informationen mit einem `quit_required`-Flag — das ist vermutlich der eigentliche Grund warum Alarme nach einem Reset am Gerät in HA nicht korrekt verschwinden. Das vollständige Handling dafür würde den Scope dieses PRs sprengen — ich würde das gerne in einem separaten PR angehen wenn Interesse besteht. Related to #17.

---

Ich habe leider kein Home Assistant zum Testen — falls du etwas siehst das angepasst werden soll, gerne melden!

Grüße

Closes #24
Closes #12