### PR TITLE
fix(select): use round() instead of int() for coefficient conversion

### DIFF
--- a/custom_components/bayrol/select.py
+++ b/custom_components/bayrol/select.py
@@ -32,27 +32,35 @@ def _handle_select_value(select, value):
     """Handle incoming select value."""
     _LOGGER.debug("Received MQTT value: %s for select: %s", value, select._attr_name)
     _LOGGER.debug("Available options: %s", select._attr_options)
-    
+
     # Try to find the value in the device-specific mappings and store the TEXT value
     if select._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
         if str(value) in PM5_MQTT_TO_TEXT_MAPPING:
             select._attr_current_option = PM5_MQTT_TO_TEXT_MAPPING[str(value)]
-            _LOGGER.debug("PM5 mapping found: %s -> %s", value, select._attr_current_option)
+            _LOGGER.debug(
+                "PM5 mapping found: %s -> %s", value, select._attr_current_option
+            )
         else:
             # Try coefficient conversion for numeric values
             _handle_numeric_value(select, value)
-    elif (select._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH" or 
-          select._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"):
+    elif (
+        select._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH"
+        or select._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"
+    ):
         if str(value) in AUTOMATIC_MQTT_TO_TEXT_MAPPING:
             select._attr_current_option = AUTOMATIC_MQTT_TO_TEXT_MAPPING[str(value)]
-            _LOGGER.debug("Automatic mapping found: %s -> %s", value, select._attr_current_option)
+            _LOGGER.debug(
+                "Automatic mapping found: %s -> %s", value, select._attr_current_option
+            )
         else:
             # Try coefficient conversion for numeric values
             _handle_numeric_value(select, value)
     else:
-        _LOGGER.warning("Unknown device type: %s", select._config_entry.data[BAYROL_DEVICE_TYPE])
+        _LOGGER.warning(
+            "Unknown device type: %s", select._config_entry.data[BAYROL_DEVICE_TYPE]
+        )
         _handle_numeric_value(select, value)
-    
+
     _LOGGER.debug("Set current_option to: %s", select._attr_current_option)
     if select.hass is not None:
         select.schedule_update_ha_state()
@@ -64,8 +72,13 @@ def _handle_numeric_value(select, value):
         coefficient = select._select_config.get("coefficient")
         if coefficient is not None and coefficient != -1:
             converted_value = float(value) / coefficient
-            _LOGGER.debug("Converted value using coefficient %s: %s -> %s", coefficient, value, converted_value)
-            
+            _LOGGER.debug(
+                "Converted value using coefficient %s: %s -> %s",
+                coefficient,
+                value,
+                converted_value,
+            )
+
             # Find the closest option
             if coefficient == 1:
                 converted_value = int(converted_value)
@@ -73,7 +86,7 @@ def _handle_numeric_value(select, value):
             else:
                 converted_value = float(converted_value)
                 options = [float(opt) for opt in select._attr_options]
-            
+
             closest_option = min(options, key=lambda x: abs(x - converted_value))
             select._attr_current_option = str(closest_option)
             _LOGGER.debug("Found closest option: %s", closest_option)
@@ -156,22 +169,24 @@ class BayrolSelect(SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         _LOGGER.debug("User selected option: %s", option)
-        
+
         # Convert display text back to MQTT value based on device type
         mqtt_value = None
-        
+
         if self._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
             # Use PM5 specific mappings
             if option in PM5_TEXT_TO_MQTT_MAPPING:
                 mqtt_value = PM5_TEXT_TO_MQTT_MAPPING[option]
                 _LOGGER.debug("PM5 text mapping: %s -> %s", option, mqtt_value)
-        elif (self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH" or 
-              self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"):
+        elif (
+            self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH"
+            or self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"
+        ):
             # Use Automatic specific mappings
             if option in AUTOMATIC_TEXT_TO_MQTT_MAPPING:
                 mqtt_value = AUTOMATIC_TEXT_TO_MQTT_MAPPING[option]
                 _LOGGER.debug("Automatic text mapping: %s -> %s", option, mqtt_value)
-        
+
         if mqtt_value is None:
             # If no text mapping found, try coefficient conversion for numeric options
             try:
@@ -179,9 +194,13 @@ class BayrolSelect(SelectEntity):
                 if coefficient is not None and coefficient != -1:
                     # Convert display value to MQTT value
                     display_float = float(option)
-                    mqtt_value = str(int(display_float * coefficient))
-                    _LOGGER.debug("Converted display value %s to MQTT value %s using coefficient %s", 
-                                option, mqtt_value, coefficient)
+                    mqtt_value = str(round(display_float * coefficient))
+                    _LOGGER.debug(
+                        "Converted display value %s to MQTT value %s using coefficient %s",
+                        option,
+                        mqtt_value,
+                        coefficient,
+                    )
                 else:
                     # No coefficient, use option as MQTT value directly
                     mqtt_value = option
@@ -195,13 +214,19 @@ class BayrolSelect(SelectEntity):
         # For numeric options, check if the original option is in options
         if mqtt_value in self._attr_options:
             # This is a text mapping case (like Production Rate)
-            _LOGGER.debug("Text mapping case: MQTT value %s found in options", mqtt_value)
+            _LOGGER.debug(
+                "Text mapping case: MQTT value %s found in options", mqtt_value
+            )
         elif option in self._attr_options:
             # This is a numeric case (like Salt Level)
             _LOGGER.debug("Numeric case: option %s found in options", option)
         else:
-            _LOGGER.error("Invalid option: %s (MQTT value: %s). Available options: %s", 
-                         option, mqtt_value, self._attr_options)
+            _LOGGER.error(
+                "Invalid option: %s (MQTT value: %s). Available options: %s",
+                option,
+                mqtt_value,
+                self._attr_options,
+            )
             return
 
         # Update the current option to the TEXT value (user's selection)
@@ -221,15 +246,17 @@ class BayrolSelect(SelectEntity):
         for option in self._attr_options:
             # Convert option to string for mapping lookup
             option_str = str(option)
-            
+
             if self._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
                 # Use PM5 specific mappings
                 if option_str in PM5_MQTT_TO_TEXT_MAPPING:
                     display_options.append(PM5_MQTT_TO_TEXT_MAPPING[option_str])
                 else:
                     display_options.append(option_str)
-            elif (self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH" or 
-                  self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"):
+            elif (
+                self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH"
+                or self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"
+            ):
                 # Use Automatic specific mappings
                 if option_str in AUTOMATIC_MQTT_TO_TEXT_MAPPING:
                     display_options.append(AUTOMATIC_MQTT_TO_TEXT_MAPPING[option_str])
@@ -237,11 +264,13 @@ class BayrolSelect(SelectEntity):
                     display_options.append(option_str)
             else:
                 # Unknown device type - this should not happen
-                _LOGGER.warning("Unknown device type: %s. Cannot map option: %s", 
-                               self._config_entry.data[BAYROL_DEVICE_TYPE], option_str)
+                _LOGGER.warning(
+                    "Unknown device type: %s. Cannot map option: %s",
+                    self._config_entry.data[BAYROL_DEVICE_TYPE],
+                    option_str,
+                )
                 display_options.append(option_str)
         return display_options
-
 
     @property
     def device_info(self) -> DeviceInfo:


### PR DESCRIPTION
Teil von #24 — aufgeteilt auf Wunsch.

`int()` schneidet Dezimalstellen ab statt zu runden. Beispiel: `7.1 * 100 = 709.999... → int = 709` statt `710`.

Das führt dazu dass Select-Werte (pH-Sollwert, Redox-Schwelle etc.) eine Einheit zu niedrig ans Gerät geschrieben werden. `round()` gibt das korrekte Ergebnis.