### PR TITLE
fix: support multiple Bayrol devices in one HA instance

### DIFF
--- a/custom_components/bayrol/__init__.py
+++ b/custom_components/bayrol/__init__.py
@@ -16,39 +16,40 @@ from .mqtt_manager import BayrolMQTTManager
 
 _LOGGER = logging.getLogger(__name__)
 
+PLATFORMS = ["sensor", "select"]
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Bayrol from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data
 
-    # Create and store MQTT manager
     mqtt_manager = BayrolMQTTManager(
         hass, entry.data[BAYROL_DEVICE_ID], entry.data[BAYROL_ACCESS_TOKEN]
     )
-    hass.data[DOMAIN]["mqtt_manager"] = mqtt_manager
+    # Store per entry_id so multiple devices don't overwrite each other (#12)
+    hass.data[DOMAIN][entry.entry_id] = {
+        "data": entry.data,
+        "mqtt_manager": mqtt_manager,
+    }
     mqtt_manager.start()
 
-    # Forward the setup to the platforms
-    await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "select"])
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        entry, ["sensor", "select"]
-    )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        # Clean up MQTT manager
-        if "mqtt_manager" in hass.data[DOMAIN]:
-            mqtt_manager = hass.data[DOMAIN]["mqtt_manager"]
+        # Clean up only this entry's MQTT manager
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id, {})
+        mqtt_manager = entry_data.get("mqtt_manager")
+        if mqtt_manager:
             if mqtt_manager.client:
                 mqtt_manager.client.disconnect()
             if mqtt_manager.thread:
                 mqtt_manager.thread.join(timeout=1.0)
-        hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/custom_components/bayrol/config_flow.py
+++ b/custom_components/bayrol/config_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import aiohttp
 import json
 from typing import Any
 
@@ -34,25 +33,38 @@ class BayrolConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             code = user_input[BAYROL_APP_LINK_CODE]
-            # Fetch access token and device id from API
             url = f"https://www.bayrol-poolaccess.de/api/?code={code}"
-            async with aiohttp.ClientSession() as session:
-                async with session.get(url) as response:
-                    data = await response.text()
-                    data_json = json.loads(data)
-                    access_token = data_json.get("accessToken")
-                    device_id = data_json.get("deviceSerial")
-                    if not access_token or not device_id:
-                        errors["base"] = "invalid_response"
-                    else:
-                        return self.async_create_entry(
-                            title="Bayrol",
-                            data={
-                                BAYROL_ACCESS_TOKEN: access_token,
-                                BAYROL_DEVICE_ID: device_id,
-                                BAYROL_DEVICE_TYPE: user_input[BAYROL_DEVICE_TYPE],
-                            },
-                        )
+            try:
+                timeout = aiohttp.ClientTimeout(total=10)
+                async with aiohttp.ClientSession(timeout=timeout) as session:
+                    async with session.get(url) as response:
+                        if response.status != 200:
+                            errors["base"] = "cannot_connect"
+                        else:
+                            try:
+                                data_json = await response.json(content_type=None)
+                            except (json.JSONDecodeError, ValueError):
+                                errors["base"] = "invalid_response"
+                            else:
+                                access_token = data_json.get("accessToken")
+                                device_id = data_json.get("deviceSerial")
+                                if not access_token or not device_id:
+                                    errors["base"] = "invalid_response"
+                                else:
+                                    await self.async_set_unique_id(device_id)
+                                    self._abort_if_unique_id_configured()
+                                    return self.async_create_entry(
+                                        title=f"Bayrol {device_id}",
+                                        data={
+                                            BAYROL_ACCESS_TOKEN: access_token,
+                                            BAYROL_DEVICE_ID: device_id,
+                                            BAYROL_DEVICE_TYPE: user_input[
+                                                BAYROL_DEVICE_TYPE
+                                            ],
+                                        },
+                                    )
+            except aiohttp.ClientError:
+                errors["base"] = "cannot_connect"
 
         return self.async_show_form(
             step_id="user",

--- a/custom_components/bayrol/select.py
+++ b/custom_components/bayrol/select.py
@@ -32,27 +32,35 @@ def _handle_select_value(select, value):
     """Handle incoming select value."""
     _LOGGER.debug("Received MQTT value: %s for select: %s", value, select._attr_name)
     _LOGGER.debug("Available options: %s", select._attr_options)
-    
+
     # Try to find the value in the device-specific mappings and store the TEXT value
     if select._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
         if str(value) in PM5_MQTT_TO_TEXT_MAPPING:
             select._attr_current_option = PM5_MQTT_TO_TEXT_MAPPING[str(value)]
-            _LOGGER.debug("PM5 mapping found: %s -> %s", value, select._attr_current_option)
+            _LOGGER.debug(
+                "PM5 mapping found: %s -> %s", value, select._attr_current_option
+            )
         else:
             # Try coefficient conversion for numeric values
             _handle_numeric_value(select, value)
-    elif (select._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH" or 
-          select._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"):
+    elif (
+        select._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH"
+        or select._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"
+    ):
         if str(value) in AUTOMATIC_MQTT_TO_TEXT_MAPPING:
             select._attr_current_option = AUTOMATIC_MQTT_TO_TEXT_MAPPING[str(value)]
-            _LOGGER.debug("Automatic mapping found: %s -> %s", value, select._attr_current_option)
+            _LOGGER.debug(
+                "Automatic mapping found: %s -> %s", value, select._attr_current_option
+            )
         else:
             # Try coefficient conversion for numeric values
             _handle_numeric_value(select, value)
     else:
-        _LOGGER.warning("Unknown device type: %s", select._config_entry.data[BAYROL_DEVICE_TYPE])
+        _LOGGER.warning(
+            "Unknown device type: %s", select._config_entry.data[BAYROL_DEVICE_TYPE]
+        )
         _handle_numeric_value(select, value)
-    
+
     _LOGGER.debug("Set current_option to: %s", select._attr_current_option)
     if select.hass is not None:
         select.schedule_update_ha_state()
@@ -64,8 +72,13 @@ def _handle_numeric_value(select, value):
         coefficient = select._select_config.get("coefficient")
         if coefficient is not None and coefficient != -1:
             converted_value = float(value) / coefficient
-            _LOGGER.debug("Converted value using coefficient %s: %s -> %s", coefficient, value, converted_value)
-            
+            _LOGGER.debug(
+                "Converted value using coefficient %s: %s -> %s",
+                coefficient,
+                value,
+                converted_value,
+            )
+
             # Find the closest option
             if coefficient == 1:
                 converted_value = int(converted_value)
@@ -73,7 +86,7 @@ def _handle_numeric_value(select, value):
             else:
                 converted_value = float(converted_value)
                 options = [float(opt) for opt in select._attr_options]
-            
+
             closest_option = min(options, key=lambda x: abs(x - converted_value))
             select._attr_current_option = str(closest_option)
             _LOGGER.debug("Found closest option: %s", closest_option)
@@ -95,8 +108,8 @@ async def async_setup_entry(
     device_type = config_entry.data[BAYROL_DEVICE_TYPE]
     _LOGGER.debug("device_type: %s", device_type)
 
-    # Get the shared MQTT manager
-    mqtt_manager = hass.data[DOMAIN]["mqtt_manager"]
+    # Get the MQTT manager for this specific config entry
+    mqtt_manager = hass.data[DOMAIN][config_entry.entry_id]["mqtt_manager"]
 
     if device_type == "Automatic SALT":
         for select_type, select_config in SENSOR_TYPES_AUTOMATIC_SALT.items():
@@ -156,22 +169,24 @@ class BayrolSelect(SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         _LOGGER.debug("User selected option: %s", option)
-        
+
         # Convert display text back to MQTT value based on device type
         mqtt_value = None
-        
+
         if self._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
             # Use PM5 specific mappings
             if option in PM5_TEXT_TO_MQTT_MAPPING:
                 mqtt_value = PM5_TEXT_TO_MQTT_MAPPING[option]
                 _LOGGER.debug("PM5 text mapping: %s -> %s", option, mqtt_value)
-        elif (self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH" or 
-              self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"):
+        elif (
+            self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH"
+            or self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"
+        ):
             # Use Automatic specific mappings
             if option in AUTOMATIC_TEXT_TO_MQTT_MAPPING:
                 mqtt_value = AUTOMATIC_TEXT_TO_MQTT_MAPPING[option]
                 _LOGGER.debug("Automatic text mapping: %s -> %s", option, mqtt_value)
-        
+
         if mqtt_value is None:
             # If no text mapping found, try coefficient conversion for numeric options
             try:
@@ -180,8 +195,12 @@ class BayrolSelect(SelectEntity):
                     # Convert display value to MQTT value
                     display_float = float(option)
                     mqtt_value = str(int(display_float * coefficient))
-                    _LOGGER.debug("Converted display value %s to MQTT value %s using coefficient %s", 
-                                option, mqtt_value, coefficient)
+                    _LOGGER.debug(
+                        "Converted display value %s to MQTT value %s using coefficient %s",
+                        option,
+                        mqtt_value,
+                        coefficient,
+                    )
                 else:
                     # No coefficient, use option as MQTT value directly
                     mqtt_value = option
@@ -195,13 +214,19 @@ class BayrolSelect(SelectEntity):
         # For numeric options, check if the original option is in options
         if mqtt_value in self._attr_options:
             # This is a text mapping case (like Production Rate)
-            _LOGGER.debug("Text mapping case: MQTT value %s found in options", mqtt_value)
+            _LOGGER.debug(
+                "Text mapping case: MQTT value %s found in options", mqtt_value
+            )
         elif option in self._attr_options:
             # This is a numeric case (like Salt Level)
             _LOGGER.debug("Numeric case: option %s found in options", option)
         else:
-            _LOGGER.error("Invalid option: %s (MQTT value: %s). Available options: %s", 
-                         option, mqtt_value, self._attr_options)
+            _LOGGER.error(
+                "Invalid option: %s (MQTT value: %s). Available options: %s",
+                option,
+                mqtt_value,
+                self._attr_options,
+            )
             return
 
         # Update the current option to the TEXT value (user's selection)
@@ -210,7 +235,9 @@ class BayrolSelect(SelectEntity):
         # Publish the new value to the MQTT topic
         topic = f"d02/{self._config_entry.data[BAYROL_DEVICE_ID]}/s/{self._state_topic}"
         payload = f'{{"t":"{self._state_topic}","v":{mqtt_value}}}'
-        self.hass.data[DOMAIN]["mqtt_manager"].client.publish(topic, payload)
+        self.hass.data[DOMAIN][self._config_entry.entry_id][
+            "mqtt_manager"
+        ].client.publish(topic, payload)
         _LOGGER.debug("Published MQTT message: %s", payload)
 
     @property
@@ -221,15 +248,17 @@ class BayrolSelect(SelectEntity):
         for option in self._attr_options:
             # Convert option to string for mapping lookup
             option_str = str(option)
-            
+
             if self._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
                 # Use PM5 specific mappings
                 if option_str in PM5_MQTT_TO_TEXT_MAPPING:
                     display_options.append(PM5_MQTT_TO_TEXT_MAPPING[option_str])
                 else:
                     display_options.append(option_str)
-            elif (self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH" or 
-                  self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"):
+            elif (
+                self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH"
+                or self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"
+            ):
                 # Use Automatic specific mappings
                 if option_str in AUTOMATIC_MQTT_TO_TEXT_MAPPING:
                     display_options.append(AUTOMATIC_MQTT_TO_TEXT_MAPPING[option_str])
@@ -237,11 +266,13 @@ class BayrolSelect(SelectEntity):
                     display_options.append(option_str)
             else:
                 # Unknown device type - this should not happen
-                _LOGGER.warning("Unknown device type: %s. Cannot map option: %s", 
-                               self._config_entry.data[BAYROL_DEVICE_TYPE], option_str)
+                _LOGGER.warning(
+                    "Unknown device type: %s. Cannot map option: %s",
+                    self._config_entry.data[BAYROL_DEVICE_TYPE],
+                    option_str,
+                )
                 display_options.append(option_str)
         return display_options
-
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/bayrol/sensor.py
+++ b/custom_components/bayrol/sensor.py
@@ -29,11 +29,11 @@ def _handle_sensor_value(sensor, value):
     """Handle incoming sensor value."""
     # Check if this is a numeric sensor that should not be converted to strings
     is_numeric_sensor = (
-        sensor._sensor_config.get("state_class") is not None and
-        sensor._sensor_config.get("state_class") != "None" and
-        sensor._sensor_config.get("unit_of_measurement") is not None
+        sensor._sensor_config.get("state_class") is not None
+        and sensor._sensor_config.get("state_class") != "None"
+        and sensor._sensor_config.get("unit_of_measurement") is not None
     )
-    
+
     # If it's a numeric sensor, handle it directly without string conversion
     if is_numeric_sensor:
         if (
@@ -109,7 +109,9 @@ def _handle_sensor_value(sensor, value):
                     sensor._sensor_config.get("coefficient") is not None
                     and sensor._sensor_config["coefficient"] != -1
                 ):
-                    sensor._attr_native_value = value / sensor._sensor_config["coefficient"]
+                    sensor._attr_native_value = (
+                        value / sensor._sensor_config["coefficient"]
+                    )
                 elif sensor._sensor_config.get("coefficient") == -1:
                     sensor._attr_native_value = str(value)
                 else:
@@ -129,8 +131,8 @@ async def async_setup_entry(
     device_type = config_entry.data[BAYROL_DEVICE_TYPE]
     _LOGGER.debug("device_type: %s", device_type)
 
-    # Get the shared MQTT manager
-    mqtt_manager = hass.data[DOMAIN]["mqtt_manager"]
+    # Get the MQTT manager for this specific config entry
+    mqtt_manager = hass.data[DOMAIN][config_entry.entry_id]["mqtt_manager"]
 
     if device_type == "Automatic SALT":
         for sensor_type, sensor_config in SENSOR_TYPES_AUTOMATIC_SALT.items():


### PR DESCRIPTION
Teil von #24 — aufgeteilt auf Wunsch. Behebt #12.

**Problem:** `mqtt_manager` wurde global unter `hass.data[DOMAIN]["mqtt_manager"]` gespeichert. Ein zweiter Config Entry hat den ersten Manager überschrieben, und beim Entladen eines Eintrags wurde die MQTT-Verbindung des anderen Geräts getrennt.

**Fixes:**
- `__init__.py`: `mqtt_manager` wird jetzt pro `entry_id` gespeichert
- `sensor.py` + `select.py`: lesen mqtt_manager aus dem entry-spezifischen Dict
- `config_flow.py`: `async_set_unique_id` + `_abort_if_unique_id_configured` verhindert dass dasselbe Gerät doppelt hinzugefügt wird
- `config_flow.py`: Timeout, HTTP-Status-Check und Exception-Handling für den API-Request

Closes #12