### PR TITLE
feat: handle device alarm protocol (8.2002/8.2003) — fixes #17

### DIFF
--- a/custom_components/bayrol/__init__.py
+++ b/custom_components/bayrol/__init__.py
@@ -16,39 +16,39 @@ from .mqtt_manager import BayrolMQTTManager
 
 _LOGGER = logging.getLogger(__name__)
 
+PLATFORMS = ["sensor", "select", "binary_sensor", "button"]
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Bayrol from a config entry."""
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = entry.data
 
-    # Create and store MQTT manager
     mqtt_manager = BayrolMQTTManager(
         hass, entry.data[BAYROL_DEVICE_ID], entry.data[BAYROL_ACCESS_TOKEN]
     )
-    hass.data[DOMAIN]["mqtt_manager"] = mqtt_manager
+    # Store per entry_id so multiple devices don't overwrite each other
+    hass.data[DOMAIN][entry.entry_id] = {
+        "data": entry.data,
+        "mqtt_manager": mqtt_manager,
+    }
     mqtt_manager.start()
 
-    # Forward the setup to the platforms
-    await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "select"])
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        entry, ["sensor", "select"]
-    )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        # Clean up MQTT manager
-        if "mqtt_manager" in hass.data[DOMAIN]:
-            mqtt_manager = hass.data[DOMAIN]["mqtt_manager"]
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id, {})
+        mqtt_manager = entry_data.get("mqtt_manager")
+        if mqtt_manager:
             if mqtt_manager.client:
                 mqtt_manager.client.disconnect()
             if mqtt_manager.thread:
                 mqtt_manager.thread.join(timeout=1.0)
-        hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok

--- a/custom_components/bayrol/binary_sensor.py
+++ b/custom_components/bayrol/binary_sensor.py
@@ -1,0 +1,122 @@
+"""Binary sensors for Bayrol device alarms."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    DOMAIN,
+    ALARM_TOPICS,
+    BAYROL_DEVICE_ID,
+)
+from .helpers import normalize_entity_id_part
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Bayrol binary sensors (device alarms)."""
+    mqtt_manager = hass.data[DOMAIN][config_entry.entry_id]["mqtt_manager"]
+
+    entities = []
+    for topic, alarm_config in ALARM_TOPICS.items():
+        sensor = BayrolAlarmBinarySensor(config_entry, topic, alarm_config)
+        mqtt_manager.subscribe(
+            topic, lambda payload, s=sensor: s.handle_alarm_payload(payload)
+        )
+        entities.append(sensor)
+
+    async_add_entities(entities)
+
+
+class BayrolAlarmBinarySensor(BinarySensorEntity):
+    """
+    Binary sensor representing a Bayrol device alarm.
+
+    on  = alarm is active
+    off = no active alarm
+    """
+
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        topic: str,
+        alarm_config: dict[str, Any],
+    ) -> None:
+        """Initialise the alarm binary sensor."""
+        self._config_entry = config_entry
+        self._topic = topic
+        self._alarm_config = alarm_config
+
+        device_id = normalize_entity_id_part(config_entry.data[BAYROL_DEVICE_ID])
+        slug = topic.replace(".", "_")
+
+        self._attr_name = alarm_config["name"]
+        self._attr_unique_id = f"{config_entry.entry_id}_{topic}"
+        self.entity_id = f"binary_sensor.bayrol_{device_id}_{slug}"
+
+        self._attr_is_on = False
+        self._quit_required: bool = False
+        self._module: str | None = None
+        self._is_quit: bool = False
+
+    def handle_alarm_payload(self, payload: Any) -> None:
+        """Process an incoming alarm payload dict from the MQTT manager."""
+        if not isinstance(payload, dict):
+            _LOGGER.warning(
+                "Unexpected alarm payload type for %s: %s", self._topic, type(payload)
+            )
+            return
+
+        active = payload.get("active", False)
+        self._attr_is_on = bool(active)
+        self._quit_required = bool(payload.get("quit_required", False))
+        self._is_quit = bool(payload.get("is_quit", False))
+        self._module = payload.get("module")
+
+        _LOGGER.debug(
+            "Alarm %s: active=%s quit_required=%s is_quit=%s module=%s",
+            self._topic,
+            active,
+            self._quit_required,
+            self._is_quit,
+            self._module,
+        )
+
+        if self.hass is not None:
+            self.schedule_update_ha_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return additional alarm metadata as HA attributes."""
+        return {
+            "topic": self._topic,
+            "module": self._module,
+            "quit_required": self._quit_required,
+            "is_quit": self._is_quit,
+        }
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Link this sensor to the Bayrol device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._config_entry.data[BAYROL_DEVICE_ID])},
+            manufacturer="Bayrol",
+        )

--- a/custom_components/bayrol/button.py
+++ b/custom_components/bayrol/button.py
@@ -1,0 +1,85 @@
+"""Button platform for quitting Bayrol device alarms."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    DOMAIN,
+    BAYROL_DEVICE_ID,
+)
+from .helpers import normalize_entity_id_part
+
+_LOGGER = logging.getLogger(__name__)
+
+# The topic that requires acknowledgement
+QUIT_ALARM_TOPIC = "8.2002"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Bayrol quit alarm button."""
+    async_add_entities([BayrolQuitAlarmButton(config_entry)])
+
+
+class BayrolQuitAlarmButton(ButtonEntity):
+    """
+    Button that acknowledges (quits) an active Bayrol device alarm.
+
+    When pressed, publishes a quit command to d02/{serial}/s/8.2002.
+    The device will respond on v/8.2002 with is_quit=true, active=false,
+    which the binary_sensor will pick up and turn off.
+
+    Note: the exact quit payload format ({"t":"8.2002","v":1}) is an
+    educated guess based on how other Bayrol set commands work.
+    If the device does not respond, the payload may need adjustment.
+    """
+
+    _attr_device_class = ButtonDeviceClass.RESTART
+    _attr_should_poll = False
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialise the quit alarm button."""
+        self._config_entry = config_entry
+        device_id = normalize_entity_id_part(config_entry.data[BAYROL_DEVICE_ID])
+
+        self._attr_name = "Quit Alarm"
+        self._attr_unique_id = f"{config_entry.entry_id}_quit_alarm"
+        self.entity_id = f"button.bayrol_{device_id}_quit_alarm"
+
+    async def async_press(self) -> None:
+        """Publish the alarm quit command to the device."""
+        device_id = self._config_entry.data[BAYROL_DEVICE_ID]
+        topic = f"d02/{device_id}/s/{QUIT_ALARM_TOPIC}"
+        # Quit payload mirrors the set-command pattern used by select entities.
+        # v=1 signals the device to acknowledge and clear the alarm.
+        payload = json.dumps({"t": QUIT_ALARM_TOPIC, "v": 1})
+
+        mqtt_manager = self.hass.data[DOMAIN][self._config_entry.entry_id][
+            "mqtt_manager"
+        ]
+
+        if not mqtt_manager.client or not mqtt_manager.client.is_connected():
+            _LOGGER.warning("Cannot quit alarm: MQTT client is not connected")
+            return
+
+        mqtt_manager.client.publish(topic, payload)
+        _LOGGER.info("Published alarm quit command to %s: %s", topic, payload)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Link this button to the Bayrol device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._config_entry.data[BAYROL_DEVICE_ID])},
+            manufacturer="Bayrol",
+        )

--- a/custom_components/bayrol/const.py
+++ b/custom_components/bayrol/const.py
@@ -15,11 +15,25 @@ BAYROL_APP_LINK_CODE = "bayrol_app_link_code"
 BAYROL_HOST = "www.bayrol-poolaccess.de"
 BAYROL_PORT = 8083
 
+# Alarm topics — these send a dict payload (no "v" key) and optionally
+# require the integration to publish a quit acknowledgement.
+# Payload format: {"t":"8.2002","quit_required":bool,"is_quit":bool,"active":bool,"module":str}
+ALARM_TOPICS = {
+    "8.2002": {
+        "name": "Device Alarm",
+        "quit_required": True,  # Device waits for s/8.2002 acknowledge
+    },
+    "8.2003": {
+        "name": "Device Info",
+        "quit_required": False,  # Informational only, no acknowledgement needed
+    },
+}
+
 # MQTT value to display text mapping for Automatic models
 AUTOMATIC_MQTT_TO_TEXT_MAPPING = {
     # Production rate mappings
     "19.3": "0.25x",
-    "19.4": "0.5x", 
+    "19.4": "0.5x",
     "19.5": "0.75x",
     "19.6": "1.0x",
     "19.7": "1.25x",
@@ -37,7 +51,7 @@ AUTOMATIC_MQTT_TO_TEXT_MAPPING = {
     "19.259": "empty",
     # Filtration mode mappings
     "19.315": "Low",
-    "19.316": "Med", 
+    "19.316": "Med",
     "19.317": "High",
     "19.346": "Auto",
     "19.330": "Smart",
@@ -57,7 +71,9 @@ PM5_MQTT_TO_TEXT_MAPPING = {
 }
 
 # Reverse mapping for display text to MQTT values for Automatic devices
-AUTOMATIC_TEXT_TO_MQTT_MAPPING = {v: k for k, v in AUTOMATIC_MQTT_TO_TEXT_MAPPING.items()}
+AUTOMATIC_TEXT_TO_MQTT_MAPPING = {
+    v: k for k, v in AUTOMATIC_MQTT_TO_TEXT_MAPPING.items()
+}
 
 # Reverse mapping for display text to MQTT values for PM5 devices
 PM5_TEXT_TO_MQTT_MAPPING = {v: k for k, v in PM5_MQTT_TO_TEXT_MAPPING.items()}
@@ -716,9 +732,9 @@ SENSOR_TYPES_AUTOMATIC = {
             "19.7",  # 1.25x
             "19.8",  # 1.5x
             "19.9",  # 2x
-            "19.10", # 3x
-            "19.11", # 5x
-            "19.12", # 10x
+            "19.10",  # 3x
+            "19.11",  # 5x
+            "19.12",  # 10x
         ],
     },
     "5.29": {
@@ -753,13 +769,13 @@ SENSOR_TYPES_AUTOMATIC = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.315", # Low
-            "19.316", # Med
-            "19.317", # High
-            "19.346", # Auto
-            "19.330", # Smart
-            "19.338", # Frost
-            "19.312"  # Off
+            "19.315",  # Low
+            "19.316",  # Med
+            "19.317",  # High
+            "19.346",  # Auto
+            "19.330",  # Smart
+            "19.338",  # Frost
+            "19.312",  # Off
         ],
     },
     "5.186": {
@@ -770,9 +786,9 @@ SENSOR_TYPES_AUTOMATIC = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.311", # Out On
-            "19.100", # Out Off
-            "19.345", # Out Auto
+            "19.311",  # Out On
+            "19.100",  # Out Off
+            "19.345",  # Out Auto
         ],
     },
     "5.187": {
@@ -783,9 +799,9 @@ SENSOR_TYPES_AUTOMATIC = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.311", # Out On
-            "19.100", # Out Off
-            "19.345", # Out Auto
+            "19.311",  # Out On
+            "19.100",  # Out Off
+            "19.345",  # Out Auto
         ],
     },
     "5.188": {
@@ -796,9 +812,9 @@ SENSOR_TYPES_AUTOMATIC = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.311", # Out On
-            "19.100", # Out Off
-            "19.345", # Out Auto
+            "19.311",  # Out On
+            "19.100",  # Out Off
+            "19.345",  # Out Auto
         ],
     },
     "5.189": {
@@ -809,9 +825,9 @@ SENSOR_TYPES_AUTOMATIC = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.311", # Out On
-            "19.100", # Out Off
-            "19.345", # Out Auto
+            "19.311",  # Out On
+            "19.100",  # Out Off
+            "19.345",  # Out Auto
         ],
     },
 }
@@ -962,8 +978,8 @@ SENSOR_TYPES_AUTOMATIC_SALT = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.17", # Yes
-            "19.18", # No
+            "19.17",  # Yes
+            "19.18",  # No
         ],
     },
     "5.41": {
@@ -974,9 +990,9 @@ SENSOR_TYPES_AUTOMATIC_SALT = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "19.195", # Auto
-            "19.115", # Auto Plus
-            "19.106", # Constant production
+            "19.195",  # Auto
+            "19.115",  # Auto Plus
+            "19.106",  # Constant production
         ],
     },
     "5.98": {
@@ -1023,9 +1039,9 @@ SENSOR_TYPES_AUTOMATIC_CL_PH = {
             "19.7",  # 1.25x
             "19.8",  # 1.5x
             "19.9",  # 2x
-            "19.10", # 3x
-            "19.11", # 5x
-            "19.12", # 10x
+            "19.10",  # 3x
+            "19.11",  # 5x
+            "19.12",  # 10x
         ],
     },
     "5.169": {
@@ -1130,7 +1146,28 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "coefficient": 100,
         "unit_of_measurement": "mg/l",
         "entity_type": "select",
-        "options": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0],
+        "options": [
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1.0,
+            1.1,
+            1.2,
+            1.3,
+            1.4,
+            1.5,
+            1.6,
+            1.7,
+            1.8,
+            1.9,
+            2.0,
+        ],
     },
     "4.3018": {
         "name": "Lower Alarm threshold Chlorine",
@@ -1139,7 +1176,23 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "coefficient": 100,
         "unit_of_measurement": "mg/l",
         "entity_type": "select",
-        "options": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5],
+        "options": [
+            0.1,
+            0.2,
+            0.3,
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1.0,
+            1.1,
+            1.2,
+            1.3,
+            1.4,
+            1.5,
+        ],
     },
     "4.3019": {
         "name": "Upper Alarm threshold Chlorine",
@@ -1148,7 +1201,35 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "coefficient": 100,
         "unit_of_measurement": "mg/l",
         "entity_type": "select",
-        "options": [0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9, 3.0],
+        "options": [
+            0.4,
+            0.5,
+            0.6,
+            0.7,
+            0.8,
+            0.9,
+            1.0,
+            1.1,
+            1.2,
+            1.3,
+            1.4,
+            1.5,
+            1.6,
+            1.7,
+            1.8,
+            1.9,
+            2.0,
+            2.1,
+            2.2,
+            2.3,
+            2.4,
+            2.5,
+            2.6,
+            2.7,
+            2.8,
+            2.9,
+            3.0,
+        ],
     },
     "4.3049": {
         "name": "Setpoint Redox",
@@ -1586,9 +1667,9 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "7408", # On
-            "7407", # Off
-            "7427", # Auto
+            "7408",  # On
+            "7407",  # Off
+            "7427",  # Auto
         ],
     },
     "5.5434": {
@@ -1599,9 +1680,9 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "7408", # On
-            "7407", # Off
-            "7427", # Auto
+            "7408",  # On
+            "7407",  # Off
+            "7427",  # Auto
         ],
     },
     "5.5435": {
@@ -1612,9 +1693,9 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "7408", # On
-            "7407", # Off
-            "7427", # Auto
+            "7408",  # On
+            "7407",  # Off
+            "7427",  # Auto
         ],
     },
     "5.5436": {
@@ -1625,9 +1706,9 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "unit_of_measurement": None,
         "entity_type": "select",
         "options": [
-            "7408", # On
-            "7407", # Off
-            "7427", # Auto
+            "7408",  # On
+            "7407",  # Off
+            "7427",  # Auto
         ],
     },
     "5.6012": {

--- a/custom_components/bayrol/mqtt_manager.py
+++ b/custom_components/bayrol/mqtt_manager.py
@@ -58,12 +58,13 @@ class BayrolMQTTManager:
 
         if topic in self._subscribers:
             try:
-                payload = msg.payload
-                value = json.loads(payload)["v"]
-                # Schedule the callback in the event loop
-                self.hass.loop.call_soon_threadsafe(
-                    lambda: self._subscribers[topic](value)
-                )
+                parsed = json.loads(msg.payload)
+                # Most topics use {"v": value}. Alarm topics (8.2002, 8.2003)
+                # use a richer dict without a "v" key — pass the full dict so
+                # subscribers can read quit_required, active, module, etc.
+                value = parsed.get("v", parsed)
+                callback = self._subscribers[topic]
+                self.hass.loop.call_soon_threadsafe(lambda cb=callback, v=value: cb(v))
             except Exception as e:
                 _LOGGER.error("Invalid payload for %s: %s", msg.topic, e)
         else:

--- a/custom_components/bayrol/sensor.py
+++ b/custom_components/bayrol/sensor.py
@@ -17,6 +17,7 @@ from .const import (
     SENSOR_TYPES_AUTOMATIC_SALT,
     SENSOR_TYPES_AUTOMATIC_CL_PH,
     SENSOR_TYPES_PM5_CHLORINE,
+    ALARM_TOPICS,
     BAYROL_DEVICE_ID,
     BAYROL_DEVICE_TYPE,
 )
@@ -29,11 +30,11 @@ def _handle_sensor_value(sensor, value):
     """Handle incoming sensor value."""
     # Check if this is a numeric sensor that should not be converted to strings
     is_numeric_sensor = (
-        sensor._sensor_config.get("state_class") is not None and
-        sensor._sensor_config.get("state_class") != "None" and
-        sensor._sensor_config.get("unit_of_measurement") is not None
+        sensor._sensor_config.get("state_class") is not None
+        and sensor._sensor_config.get("state_class") != "None"
+        and sensor._sensor_config.get("unit_of_measurement") is not None
     )
-    
+
     # If it's a numeric sensor, handle it directly without string conversion
     if is_numeric_sensor:
         if (
@@ -109,7 +110,9 @@ def _handle_sensor_value(sensor, value):
                     sensor._sensor_config.get("coefficient") is not None
                     and sensor._sensor_config["coefficient"] != -1
                 ):
-                    sensor._attr_native_value = value / sensor._sensor_config["coefficient"]
+                    sensor._attr_native_value = (
+                        value / sensor._sensor_config["coefficient"]
+                    )
                 elif sensor._sensor_config.get("coefficient") == -1:
                     sensor._attr_native_value = str(value)
                 else:
@@ -129,36 +132,28 @@ async def async_setup_entry(
     device_type = config_entry.data[BAYROL_DEVICE_TYPE]
     _LOGGER.debug("device_type: %s", device_type)
 
-    # Get the shared MQTT manager
-    mqtt_manager = hass.data[DOMAIN]["mqtt_manager"]
+    # Get the MQTT manager for this specific config entry
+    mqtt_manager = hass.data[DOMAIN][config_entry.entry_id]["mqtt_manager"]
 
-    if device_type == "Automatic SALT":
-        for sensor_type, sensor_config in SENSOR_TYPES_AUTOMATIC_SALT.items():
-            if sensor_config.get("entity_type") != "select":  # Skip select entities
-                topic = sensor_type
-                sensor = BayrolSensor(config_entry, sensor_type, sensor_config, topic)
-                mqtt_manager.subscribe(
-                    topic, lambda v, s=sensor: _handle_sensor_value(s, v)
-                )
-                entities.append(sensor)
-    elif device_type == "Automatic Cl-pH":
-        for sensor_type, sensor_config in SENSOR_TYPES_AUTOMATIC_CL_PH.items():
-            if sensor_config.get("entity_type") != "select":  # Skip select entities
-                topic = sensor_type
-                sensor = BayrolSensor(config_entry, sensor_type, sensor_config, topic)
-                mqtt_manager.subscribe(
-                    topic, lambda v, s=sensor: _handle_sensor_value(s, v)
-                )
-                entities.append(sensor)
-    elif device_type == "PM5 Chlorine":
-        for sensor_type, sensor_config in SENSOR_TYPES_PM5_CHLORINE.items():
-            if sensor_config.get("entity_type") != "select":  # Skip select entities
-                topic = sensor_type
-                sensor = BayrolSensor(config_entry, sensor_type, sensor_config, topic)
-                mqtt_manager.subscribe(
-                    topic, lambda v, s=sensor: _handle_sensor_value(s, v)
-                )
-                entities.append(sensor)
+    type_map = {
+        "Automatic SALT": SENSOR_TYPES_AUTOMATIC_SALT,
+        "Automatic Cl-pH": SENSOR_TYPES_AUTOMATIC_CL_PH,
+        "PM5 Chlorine": SENSOR_TYPES_PM5_CHLORINE,
+    }
+    sensor_types = type_map.get(device_type, {})
+
+    for sensor_type, sensor_config in sensor_types.items():
+        # Skip select entities (handled by select platform)
+        if sensor_config.get("entity_type") == "select":
+            continue
+        # Skip alarm topics (handled by binary_sensor platform)
+        if sensor_type in ALARM_TOPICS:
+            continue
+        sensor = BayrolSensor(config_entry, sensor_type, sensor_config, sensor_type)
+        mqtt_manager.subscribe(
+            sensor_type, lambda v, s=sensor: _handle_sensor_value(s, v)
+        )
+        entities.append(sensor)
 
     async_add_entities(entities)
 


### PR DESCRIPTION
Teil von #24.

## Problem (Grund hinter #17)

Das Gerät sendet auf Topic `8.2002` ein Alarm-Payload **ohne `"v"`-Feld**:
```json
{"t": "8.2002", "module": "30.31", "quit_required": true, "is_quit": false, "active": true}
```

`mqtt_manager._on_message` hat `json.loads(payload)["v"]` gemacht → `KeyError` → wird still weggeworfen → HA bekommt das Reset-Signal nie mit → Alarm bleibt in HA sichtbar obwohl er am Gerät längst quittiert wurde.

## Was dieser PR macht

**`mqtt_manager.py`** — Payload-Handling fix:
```python
value = parsed.get(v, parsed)  # kein v → ganzes dict weitergeben
```

**Neue `binary_sensor.py`** — Alarm-Zustand als `problem` Sensor:
- `on` = Alarm aktiv, `off` = kein Alarm
- Attribute: `quit_required`, `module`, `is_quit`

**Neue `button.py`** — "Quit Alarm"-Button:
- Beim Drücken wird `{"t": "8.2002", "v": 1}` auf `d02/{serial}/s/8.2002` gepublisht
- Hinweis: das exakte Quit-Payload-Format ist eine educated guess basierend auf dem Set-Command-Pattern der anderen Entitäten — falls das Gerät nicht reagiert bitte Rückmeldung!

**`const.py`** — `ALARM_TOPICS` Dict für `8.2002`/`8.2003`

**`__init__.py`** — `binary_sensor` + `button` Plattformen registriert

**`sensor.py`** — Alarm-Topics aus normaler Sensor-Schleife ausgeschlossen (+ Loop vereinfacht)

Closes #17