### PR TITLE
Add PM5 Chlorine temperature setpoint and heating mode entities

### DIFF
--- a/custom_components/bayrol/__init__.py
+++ b/custom_components/bayrol/__init__.py
@@ -16,7 +16,7 @@ from .mqtt_manager import BayrolMQTTManager
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["sensor", "select", "button"]
+PLATFORMS = ["sensor", "select", "button", "number"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/bayrol/const.py
+++ b/custom_components/bayrol/const.py
@@ -1,5 +1,6 @@
 """Constants for the Bayrol integration."""
 
+from homeassistant.components.number import NumberDeviceClass
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorStateClass,
@@ -2076,5 +2077,19 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "coefficient": None,
         "unit_of_measurement": None,
         "entity_type": "sensor",
+    },
+}
+
+# Writable number types for PM5 Chlorine
+NUMBER_TYPES_PM5_CHLORINE = {
+    "4.3118": {
+        "name": "Temperature Setpoint",
+        "device_class": NumberDeviceClass.TEMPERATURE,
+        "coefficient": 10,
+        "unit_of_measurement": "°C",
+        # Limits and step reported by the PM5 MQTT metadata.
+        "min_value": 3.0,
+        "max_value": 50.0,
+        "step": 0.5,
     },
 }

--- a/custom_components/bayrol/const.py
+++ b/custom_components/bayrol/const.py
@@ -1677,6 +1677,23 @@ SENSOR_TYPES_PM5_CHLORINE = {
         "unit_of_measurement": None,
         "entity_type": "sensor",
     },
+    "5.5213": {
+        "name": "Heating Mode",
+        "device_class": None,
+        "state_class": None,
+        "coefficient": None,
+        "unit_of_measurement": None,
+        "entity_type": "select",
+        "options": [
+            "7256",  # Off
+            "7254",  # Auto
+        ],
+        # Topic-specific because Off and Auto are also used by other PM5 selects.
+        "mqtt_values": {
+            "7256": "Off",
+            "7254": "Auto",
+        },
+    },
     "5.5427": {
         "name": "Filter Pump Mode",
         "device_class": None,

--- a/custom_components/bayrol/number.py
+++ b/custom_components/bayrol/number.py
@@ -1,0 +1,102 @@
+"""Support for Bayrol number entities."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    BAYROL_DEVICE_ID,
+    BAYROL_DEVICE_TYPE,
+    DOMAIN,
+    NUMBER_TYPES_PM5_CHLORINE,
+)
+from .helpers import normalize_entity_id_part
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _handle_number_value(entity: BayrolNumber, value) -> None:
+    """Handle an incoming number value."""
+    try:
+        entity._attr_native_value = float(value) / entity._coefficient
+    except (TypeError, ValueError):
+        _LOGGER.warning(
+            "Invalid MQTT value %s for number: %s", value, entity._attr_name
+        )
+        return
+
+    if entity.hass is not None:
+        entity.schedule_update_ha_state()
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Bayrol number entities."""
+    if config_entry.data[BAYROL_DEVICE_TYPE] != "PM5 Chlorine":
+        async_add_entities([])
+        return
+
+    mqtt_manager = hass.data[DOMAIN][config_entry.entry_id]["mqtt_manager"]
+    entities = []
+
+    for topic, number_config in NUMBER_TYPES_PM5_CHLORINE.items():
+        entity = BayrolNumber(config_entry, topic, number_config)
+        mqtt_manager.subscribe(
+            topic, lambda value, number=entity: _handle_number_value(number, value)
+        )
+        entities.append(entity)
+
+    async_add_entities(entities)
+
+
+class BayrolNumber(NumberEntity):
+    """Representation of a writable Bayrol number."""
+
+    def __init__(self, config_entry, topic, number_config) -> None:
+        """Initialize the number entity."""
+        self._config_entry = config_entry
+        self._topic = topic
+        self._coefficient = number_config["coefficient"]
+        self._attr_name = number_config["name"]
+        self._attr_device_class = number_config["device_class"]
+        self._attr_native_unit_of_measurement = number_config["unit_of_measurement"]
+        self._attr_native_min_value = number_config["min_value"]
+        self._attr_native_max_value = number_config["max_value"]
+        self._attr_native_step = number_config["step"]
+        self._attr_native_value = None
+        self._attr_unique_id = f"{config_entry.entry_id}_{topic}"
+
+        device_id = normalize_entity_id_part(config_entry.data[BAYROL_DEVICE_ID])
+        name = normalize_entity_id_part(number_config["name"])
+        self.entity_id = f"number.bayrol_{device_id}_{name}"
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Publish a new native value to the Bayrol MQTT topic."""
+        mqtt_value = round(value * self._coefficient)
+        topic = f"d02/{self._config_entry.data[BAYROL_DEVICE_ID]}/s/{self._topic}"
+        payload = json.dumps(
+            {"t": self._topic, "v": mqtt_value}, separators=(",", ":")
+        )
+
+        self.hass.data[DOMAIN][self._config_entry.entry_id][
+            "mqtt_manager"
+        ].client.publish(topic, payload)
+        _LOGGER.debug("Published MQTT message: %s", payload)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._config_entry.data[BAYROL_DEVICE_ID])},
+            manufacturer="Bayrol",
+        )

--- a/custom_components/bayrol/select.py
+++ b/custom_components/bayrol/select.py
@@ -33,8 +33,16 @@ def _handle_select_value(select, value):
     _LOGGER.debug("Received MQTT value: %s for select: %s", value, select._attr_name)
     _LOGGER.debug("Available options: %s", select._attr_options)
 
-    # Try to find the value in the device-specific mappings and store the TEXT value
-    if select._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
+    # Prefer a topic-specific mapping when one is configured.
+    if str(value) in select._mqtt_to_value:
+        select._attr_current_option = select._mqtt_to_value[str(value)]
+        _LOGGER.debug(
+            "Topic-specific mapping found: %s -> %s",
+            value,
+            select._attr_current_option,
+        )
+    # Otherwise use the device-specific mappings and store the TEXT value.
+    elif select._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
         if str(value) in PM5_MQTT_TO_TEXT_MAPPING:
             select._attr_current_option = PM5_MQTT_TO_TEXT_MAPPING[str(value)]
             _LOGGER.debug(
@@ -173,14 +181,31 @@ class BayrolSelect(SelectEntity):
         # Convert display text back to MQTT value based on device type
         mqtt_value = None
 
-        if self._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
+        if self._mqtt_to_value:
+            value_to_mqtt = {
+                display_value: mqtt_value
+                for mqtt_value, display_value in self._mqtt_to_value.items()
+            }
+            mqtt_value = value_to_mqtt.get(option)
+            if mqtt_value is not None:
+                _LOGGER.debug(
+                    "Topic-specific text mapping: %s -> %s", option, mqtt_value
+                )
+
+        if (
+            mqtt_value is None
+            and self._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine"
+        ):
             # Use PM5 specific mappings
             if option in PM5_TEXT_TO_MQTT_MAPPING:
                 mqtt_value = PM5_TEXT_TO_MQTT_MAPPING[option]
                 _LOGGER.debug("PM5 text mapping: %s -> %s", option, mqtt_value)
         elif (
-            self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH"
-            or self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"
+            mqtt_value is None
+            and (
+                self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic Cl-pH"
+                or self._config_entry.data[BAYROL_DEVICE_TYPE] == "Automatic SALT"
+            )
         ):
             # Use Automatic specific mappings
             if option in AUTOMATIC_TEXT_TO_MQTT_MAPPING:
@@ -249,7 +274,9 @@ class BayrolSelect(SelectEntity):
             # Convert option to string for mapping lookup
             option_str = str(option)
 
-            if self._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
+            if option_str in self._mqtt_to_value:
+                display_options.append(self._mqtt_to_value[option_str])
+            elif self._config_entry.data[BAYROL_DEVICE_TYPE] == "PM5 Chlorine":
                 # Use PM5 specific mappings
                 if option_str in PM5_MQTT_TO_TEXT_MAPPING:
                     display_options.append(PM5_MQTT_TO_TEXT_MAPPING[option_str])


### PR DESCRIPTION
## Summary

- add a Home Assistant `number` entity for the PM5 Chlorine temperature setpoint
- subscribe to MQTT topic `4.3118` and convert the raw value using a factor of 10
- publish changed setpoints to `d02/<deviceSerial>/s/4.3118`
- expose the limits reported by the PM5 metadata: 3.0–50.0 °C in 0.5 °C steps
- add a `Heating Mode` select for MQTT topic `5.5213`
- map the heating values `7256` to `Off` and `7254` to `Auto`
- use topic-specific select mappings so existing PM5 `Off` and `Auto` values remain unaffected

## Why

The integration already exposes the PM5 Chlorine water temperature as a read-only sensor, but it does not expose the editable heating temperature setpoint or the heating operating mode. MQTT Explorer confirmed that the PM5 reports these settings as editable on topics `4.3118` and `5.5213`.

## Validation

- `python3 -m compileall -q custom_components/bayrol`
- `git diff --check`
- verified incoming raw value `275` is exposed as `27.5 °C`
- verified setting `28.0 °C` publishes `{"t":"4.3118","v":280}`
- verified the entity ID is `number.bayrol_<device_id>_temperature_setpoint`
- verified heating value `7256` is exposed as `Off`
- verified heating value `7254` is exposed as `Auto`
- verified selecting `Off` and `Auto` publishes the matching values to `5.5213`
- regression-tested that Filter Pump Mode `Off` still publishes `7393`

## Manual test status

Successfully tested on a live PM5 Chlorine device with Home Assistant 2026.7.4:

- the Temperature Setpoint entity is available in Home Assistant
- changing the setpoint from 28.0 °C to 28.5 °C was reflected by the Bayrol controller
- the Heating Mode select is available in Home Assistant
- switching Heating Mode between `Off` and `Auto` was reflected correctly by the Bayrol controller
