### PR TITLE
Add dosing switches and localized PoolAccess messages, fix MQTT threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,9 @@ Automatic SALT and Automatic Cl-pH devices also expose MQTT topic `10` as a
 `Messages` sensor. Its state contains the stable message keys used by the
 previous `bayrol-poolaccess-mqtt` bridge. The `message_codes` attribute keeps
 the raw Bayrol codes, `message_keys` exposes the stable keys for automations,
-and `messages` provides each code, key, severity and readable message. Message
-text follows Home Assistant's configured system language (French and English
-are supported, with English as the fallback). The legacy `data` attribute is
-kept as an alias for migrated templates. This includes redox warnings such as
+and `data` provides each code, key, severity and readable message. Message text
+follows Home Assistant's configured system language (French and English are
+supported, with English as the fallback). This includes redox warnings such as
 `8.9` to `8.14`, as well as the other current messages shown by PoolAccess.
 
 ### PM5 Chlorine

--- a/README.md
+++ b/README.md
@@ -127,10 +127,11 @@ Automatic SALT and Automatic Cl-pH devices also expose MQTT topic `10` as a
 `Messages` sensor. Its state contains the stable message keys used by the
 previous `bayrol-poolaccess-mqtt` bridge. The `message_codes` attribute keeps
 the raw Bayrol codes, `message_keys` exposes the stable keys for automations,
-and `messages` provides each code, key, severity and readable message. The
-legacy `data` attribute is kept as an alias for migrated templates. This
-includes redox warnings such as `8.9` to `8.14`, as well as the other current
-messages shown by PoolAccess.
+and `messages` provides each code, key, severity and readable message. Message
+text follows Home Assistant's configured system language (French and English
+are supported, with English as the fallback). The legacy `data` attribute is
+kept as an alias for migrated templates. This includes redox warnings such as
+`8.9` to `8.14`, as well as the other current messages shown by PoolAccess.
 
 ### PM5 Chlorine
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This custom integration allows you to monitor your Bayrol Pool Access device in 
 ## Features
 
 - 35 to 60+ entities per device, depending on the model (pH, Redox, Salt, chlorine, temperatures, alarm thresholds, pump and output states)
-- Writable settings as select entities (targets, alarm limits, modes) and number entities (temperature setpoints)
+- Writable settings as select entities (targets, alarm limits, modes), number entities (temperature setpoints), and switch entities (pH dosing and salt electrolysis)
+- Current device messages, including pH, redox, salt, flow and cell warnings
 - Real-time updates via MQTT connection
 
 ## Tested Devices
@@ -27,12 +28,14 @@ The **MQTT ID** is the topic suffix the device publishes under (see [MQTT Debug]
 - `sensor` – read only
 - `select` – writable, pick one of a fixed list of values
 - `number` – writable numeric value
+- `switch` – writable on/off setting
 - `button` – sends a command to the device
 
 ### Automatic SALT
 
 | MQTT ID | Name | Type | Unit |
 | --- | --- | --- | --- |
+| `10` | Messages | sensor | — |
 | `4.2` | pH Target | select | — |
 | `4.3` | pH Alert Max | select | — |
 | `4.4` | pH Alert Min | select | — |
@@ -66,8 +69,9 @@ The **MQTT ID** is the topic suffix the device publishes under (see [MQTT Debug]
 | `5.3` | pH Production Rate | select | — |
 | `5.29` | Flow Pump Status | sensor | — |
 | `5.37` | Gas Sensor | sensor | — |
-| `5.40` | Salt electrolysis ON/OFF | select | — |
+| `5.40` | Salt electrolysis ON/OFF | switch | — |
 | `5.41` | Redox Mode | select | — |
+| `5.42` | pH Dosing ON/OFF | switch | — |
 | `5.80` | pH Minus Canister Status | sensor | — |
 | `5.83` | Cover | sensor | — |
 | `5.98` | Flow Contact | sensor | — |
@@ -81,6 +85,7 @@ The **MQTT ID** is the topic suffix the device publishes under (see [MQTT Debug]
 
 | MQTT ID | Name | Type | Unit |
 | --- | --- | --- | --- |
+| `10` | Messages | sensor | — |
 | `4.2` | pH Target | select | — |
 | `4.3` | pH Alert Max | select | — |
 | `4.4` | pH Alert Min | select | — |
@@ -107,6 +112,7 @@ The **MQTT ID** is the topic suffix the device publishes under (see [MQTT Debug]
 | `5.28` | Flow In Status | sensor | — |
 | `5.29` | Flow Pump Status | sensor | — |
 | `5.37` | Gas Sensor | sensor | — |
+| `5.42` | pH Dosing ON/OFF | switch | — |
 | `5.80` | pH Minus Canister Status | sensor | — |
 | `5.83` | Cover | sensor | — |
 | `5.169` | Cl Canister Status | sensor | — |
@@ -116,6 +122,15 @@ The **MQTT ID** is the topic suffix the device publishes under (see [MQTT Debug]
 | `5.187` | Out 2 Mode | select | — |
 | `5.188` | Out 3 Mode | select | — |
 | `5.189` | Out 4 Mode | select | — |
+
+Automatic SALT and Automatic Cl-pH devices also expose MQTT topic `10` as a
+`Messages` sensor. Its state contains the stable message keys used by the
+previous `bayrol-poolaccess-mqtt` bridge. The `message_codes` attribute keeps
+the raw Bayrol codes, `message_keys` exposes the stable keys for automations,
+and `messages` provides each code, key, severity and readable message. The
+legacy `data` attribute is kept as an alias for migrated templates. This
+includes redox warnings such as `8.9` to `8.14`, as well as the other current
+messages shown by PoolAccess.
 
 ### PM5 Chlorine
 

--- a/custom_components/bayrol/__init__.py
+++ b/custom_components/bayrol/__init__.py
@@ -31,7 +31,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "data": entry.data,
         "mqtt_manager": mqtt_manager,
     }
-    mqtt_manager.start()
+    await hass.async_add_executor_job(mqtt_manager.start)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -47,9 +47,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry_data = hass.data[DOMAIN].pop(entry.entry_id, {})
         mqtt_manager = entry_data.get("mqtt_manager")
         if mqtt_manager:
-            if mqtt_manager.client:
-                mqtt_manager.client.disconnect()
-            if mqtt_manager.thread:
-                mqtt_manager.thread.join(timeout=1.0)
+            await hass.async_add_executor_job(mqtt_manager.stop)
 
     return unload_ok

--- a/custom_components/bayrol/__init__.py
+++ b/custom_components/bayrol/__init__.py
@@ -16,7 +16,7 @@ from .mqtt_manager import BayrolMQTTManager
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["sensor", "select", "button", "number", "binary_sensor"]
+PLATFORMS = ["sensor", "select", "switch", "button", "number", "binary_sensor"]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/bayrol/const.py
+++ b/custom_components/bayrol/const.py
@@ -762,6 +762,13 @@ SENSOR_TYPES_AUTOMATIC = {
             "19.12",  # 10x
         ],
     },
+    "5.42": {
+        "name": "pH Dosing ON/OFF",
+        "entity_type": "switch",
+        "on_value": "19.17",
+        "off_value": "19.18",
+        "icon": "mdi:beaker",
+    },
     "5.29": {
         "name": "Flow Pump Status",
         "device_class": None,
@@ -1005,15 +1012,10 @@ SENSOR_TYPES_AUTOMATIC_SALT = {
     },
     "5.40": {
         "name": "Salt electrolysis ON/OFF",
-        "device_class": None,
-        "state_class": None,
-        "coefficient": None,
-        "unit_of_measurement": None,
-        "entity_type": "select",
-        "options": [
-            "19.17",  # Yes
-            "19.18",  # No
-        ],
+        "entity_type": "switch",
+        "on_value": "19.17",
+        "off_value": "19.18",
+        "icon": "mdi:water-opacity",
     },
     "5.41": {
         "name": "Redox Mode",

--- a/custom_components/bayrol/manifest.json
+++ b/custom_components/bayrol/manifest.json
@@ -13,5 +13,5 @@
     "paho-mqtt==2.1.0",
     "aiohttp"
   ],
-  "version": "0.7.10"
+  "version": "0.7.11"
 }

--- a/custom_components/bayrol/mqtt_manager.py
+++ b/custom_components/bayrol/mqtt_manager.py
@@ -88,12 +88,7 @@ class BayrolMQTTManager:
             # loop_write() from the Home Assistant thread while a manually
             # created loop_forever() thread may already be writing to the same
             # WebSocket buffer.
-            connect_result = self.client.connect_async(BAYROL_HOST, BAYROL_PORT, 60)
-            if connect_result != paho.MQTT_ERR_SUCCESS:
-                raise RuntimeError(
-                    f"MQTT connect_async() failed with result {connect_result}"
-                )
-
+            self.client.connect_async(BAYROL_HOST, BAYROL_PORT, 60)
             loop_result = self.client.loop_start()
             if loop_result != paho.MQTT_ERR_SUCCESS:
                 raise RuntimeError(

--- a/custom_components/bayrol/mqtt_manager.py
+++ b/custom_components/bayrol/mqtt_manager.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import logging
-import threading
-import paho.mqtt.client as paho
 import json
+import logging
+
+import paho.mqtt.client as paho
 
 from homeassistant.core import HomeAssistant
 
@@ -26,7 +26,6 @@ class BayrolMQTTManager:
         self.mqtt_user = mqtt_user
         self.device_id = device_id
         self.client = None
-        self.thread = None
         self._subscribers = {}
 
     def subscribe(self, topic: str, callback):
@@ -72,23 +71,51 @@ class BayrolMQTTManager:
         else:
             _LOGGER.warning("Received message for unknown topic: %s", msg.topic)
 
-    def _start(self):
-        """Start the MQTT manager."""
+    def start(self):
+        """Start Paho's threaded MQTT network loop."""
+        if self.client is not None:
+            return
+
         self.client = paho.Client(transport="websockets")
         self.client.username_pw_set(self.mqtt_user, "1")
         self.client.tls_set()
         self.client.on_connect = self._on_connect
         self.client.on_message = self._on_message
-        try:
-            self.client.connect(BAYROL_HOST, BAYROL_PORT, 60)
-            _LOGGER.debug("MQTT connect() called for %s:%s", BAYROL_HOST, BAYROL_PORT)
-        except Exception as e:
-            _LOGGER.error("MQTT connect() failed: %s", e)
-        self.client.loop_forever()
 
-    def start(self):
-        """Start the MQTT manager."""
-        _LOGGER.debug("Starting MQTT manager")
-        if not self.thread:
-            self.thread = threading.Thread(target=self._start, daemon=True)
-            self.thread.start()
+        try:
+            # loop_start() registers Paho's network thread internally. This is
+            # important because publish()/subscribe() otherwise call
+            # loop_write() from the Home Assistant thread while a manually
+            # created loop_forever() thread may already be writing to the same
+            # WebSocket buffer.
+            connect_result = self.client.connect_async(BAYROL_HOST, BAYROL_PORT, 60)
+            if connect_result != paho.MQTT_ERR_SUCCESS:
+                raise RuntimeError(
+                    f"MQTT connect_async() failed with result {connect_result}"
+                )
+
+            loop_result = self.client.loop_start()
+            if loop_result != paho.MQTT_ERR_SUCCESS:
+                raise RuntimeError(
+                    f"MQTT loop_start() failed with result {loop_result}"
+                )
+            _LOGGER.debug(
+                "MQTT connect_async()/loop_start() called for %s:%s",
+                BAYROL_HOST,
+                BAYROL_PORT,
+            )
+        except Exception as e:
+            _LOGGER.error("MQTT startup failed: %s", e)
+            self.client = None
+
+    def stop(self):
+        """Disconnect and stop Paho's network thread."""
+        if self.client is None:
+            return
+
+        client = self.client
+        self.client = None
+        try:
+            client.disconnect()
+        finally:
+            client.loop_stop()

--- a/custom_components/bayrol/sensor.py
+++ b/custom_components/bayrol/sensor.py
@@ -523,9 +523,6 @@ class BayrolMessagesSensor(SensorEntity):
             "message_codes": self._message_codes,
             "message_keys": message_keys,
             "message_language": self._message_language,
-            "messages": self._messages,
-            # Compatibility alias for templates migrated from
-            # bayrol-poolaccess-mqtt's MessagesSensor.
             "data": self._messages,
         }
 

--- a/custom_components/bayrol/sensor.py
+++ b/custom_components/bayrol/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorEntity,
@@ -23,6 +24,110 @@ from .const import (
 from .helpers import normalize_entity_id_part
 
 _LOGGER = logging.getLogger(__name__)
+
+MESSAGE_TOPIC = "10"
+
+# Topic 10 is the current message list shown by the PoolAccess application.
+# Keep the stable keys from bayrol-poolaccess-mqtt so existing automations can
+# continue to match them after migrating to this integration.
+MESSAGE_DEFINITIONS = {
+    "8.5": (
+        "al_no_flow_bnc",
+        "warning",
+        "Filter pump off (no signal from paddle switch)",
+    ),
+    "8.6": (
+        "al_no_flow_230V",
+        "warning",
+        "Filter pump off (no 230V signal from the filter pump)",
+    ),
+    "8.7": ("al_start_delay", "info", "Start delay"),
+    "8.8": (
+        "al_se_gas_detected",
+        "warning",
+        "Gas detected in the cell; salt electrolysis stopped",
+    ),
+    "8.9": (
+        "al_se_err_setpoint_safe_mode",
+        "warning",
+        "Redox has been too low for several days; salt electrolysis is in Safe Mode",
+    ),
+    "8.10": (
+        "al_se_err_setpoint_stopped",
+        "warning",
+        "Redox has been too low for several days; salt electrolysis stopped",
+    ),
+    "8.11": (
+        "al_se_err_setpoint",
+        "warning",
+        "Redox has been too low for several days",
+    ),
+    "8.12": (
+        "al_se_err_rise_safe_mode",
+        "warning",
+        "Redox is not rising as expected; salt electrolysis is in Safe Mode",
+    ),
+    "8.13": (
+        "al_se_err_rise_stopped",
+        "warning",
+        "Redox is not rising as expected; salt electrolysis stopped",
+    ),
+    "8.14": ("al_se_err_rise", "warning", "Redox is not rising as expected"),
+    "8.15": (
+        "al_ph_dosing_stopped",
+        "warning",
+        "pH is not reacting as expected; pH dosing stopped",
+    ),
+    "8.16": (
+        "al_mv_dosing_stopped",
+        "warning",
+        "Redox is not reacting as expected; chlorine dosing stopped",
+    ),
+    "8.17": ("al_ph_minus_empty", "warning", "pH-Minus canister empty"),
+    "8.18": ("al_ph_plus_empty", "warning", "pH-Plus canister empty"),
+    "8.19": (
+        "al_salt_low_stopped",
+        "warning",
+        "Salt level too low; salt electrolysis stopped",
+    ),
+    "8.20": (
+        "al_salt_low_cell_protection",
+        "warning",
+        "Salt level too low; cell protection mode is active",
+    ),
+    "8.21": ("al_salt_low_pre_warning", "warning", "Salt level below preferred level"),
+    "8.22": ("al_se_production_low", "warning", "Salt electrolysis production too low"),
+    "8.23": ("al_ph_too_high", "warning", "pH reading too high"),
+    "8.24": ("al_ph_too_low", "warning", "pH reading too low"),
+    "8.25": (
+        "al_se_t_low_stopped",
+        "warning",
+        "Water temperature too low; salt electrolysis stopped",
+    ),
+    "8.26": (
+        "al_se_t_low_stopped_user",
+        "warning",
+        "Water temperature low; salt electrolysis stopped",
+    ),
+    "8.27": (
+        "al_se_t_low_cell_protection",
+        "warning",
+        "Water temperature too low; cell protection mode is active",
+    ),
+    "8.28": ("al_mv_too_high", "warning", "Redox reading too high"),
+    "8.29": ("al_mv_too_low", "warning", "Redox reading too low"),
+    "8.30": ("al_se_no_current", "warning", "No cell current"),
+    "8.31": (
+        "al_filtration_short",
+        "warning",
+        "Daily filtration time may be too short",
+    ),
+    "8.32": ("al_cl_empty", "warning", "Chlorine canister empty"),
+    "8.33": ("enjoy", "success", "Everything is OK. Enjoy your pool!"),
+    "8.34": ("ev_sw_reset", "warning", "Software reset"),
+    "8.35": ("ev_system_start", "info", "Power on"),
+    "8.36": ("ev_default_reset", "info", "Default reset"),
+}
 
 
 def _handle_sensor_value(sensor, value):
@@ -155,7 +260,8 @@ async def async_setup_entry(
             if sensor_config.get("entity_type") not in (
                 "select",
                 "number",
-            ):  # Skip select/number entities
+                "switch",
+            ):  # Skip writable entities
                 topic = sensor_type
                 sensor = BayrolSensor(config_entry, sensor_type, sensor_config, topic)
                 mqtt_manager.subscribe(
@@ -167,7 +273,8 @@ async def async_setup_entry(
             if sensor_config.get("entity_type") not in (
                 "select",
                 "number",
-            ):  # Skip select/number entities
+                "switch",
+            ):  # Skip writable entities
                 topic = sensor_type
                 sensor = BayrolSensor(config_entry, sensor_type, sensor_config, topic)
                 mqtt_manager.subscribe(
@@ -179,13 +286,19 @@ async def async_setup_entry(
             if sensor_config.get("entity_type") not in (
                 "select",
                 "number",
-            ):  # Skip select/number entities
+                "switch",
+            ):  # Skip writable entities
                 topic = sensor_type
                 sensor = BayrolSensor(config_entry, sensor_type, sensor_config, topic)
                 mqtt_manager.subscribe(
                     topic, lambda v, s=sensor: _handle_sensor_value(s, v)
                 )
                 entities.append(sensor)
+
+    if device_type in ("Automatic SALT", "Automatic Cl-pH"):
+        messages = BayrolMessagesSensor(config_entry)
+        mqtt_manager.subscribe(MESSAGE_TOPIC, messages.handle_message_payload)
+        entities.append(messages)
 
     async_add_entities(entities)
 
@@ -223,6 +336,118 @@ class BayrolSensor(SensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         """Device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._config_entry.data[BAYROL_DEVICE_ID])},
+            manufacturer="Bayrol",
+        )
+
+
+class BayrolMessagesSensor(SensorEntity):
+    """Current PoolAccess messages published on MQTT topic 10."""
+
+    _attr_name = "Messages"
+    _attr_icon = "mdi:message-bulleted"
+    _attr_should_poll = False
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize the messages sensor."""
+        self._config_entry = config_entry
+        self._attr_unique_id = f"{config_entry.entry_id}_{MESSAGE_TOPIC}"
+        device_id = normalize_entity_id_part(config_entry.data[BAYROL_DEVICE_ID])
+        self.entity_id = f"sensor.bayrol_{device_id}_messages"
+        self._attr_native_value = None
+        self._message_codes: list[str] = []
+        self._messages: list[dict[str, str]] = []
+
+    def handle_message_payload(self, payload: Any) -> None:
+        """Decode the current PoolAccess message list."""
+        if payload is None:
+            raw_codes = []
+        elif isinstance(payload, (list, tuple)):
+            raw_codes = list(payload)
+        elif isinstance(payload, (str, int, float)):
+            raw_codes = [payload]
+        else:
+            _LOGGER.warning(
+                "Unexpected MQTT payload type for Bayrol messages: %s",
+                type(payload),
+            )
+            return
+
+        self._message_codes = [self._normalize_message_code(code) for code in raw_codes]
+        self._messages = [self._message_details(code) for code in self._message_codes]
+
+        keys = [message["key"] for message in self._messages]
+        state = ", ".join(keys) if keys else "none"
+        self._attr_native_value = (
+            state if len(state) <= 255 else f"{len(keys)} messages"
+        )
+        self._attr_icon = (
+            "mdi:message-alert"
+            if any(message["type"] == "warning" for message in self._messages)
+            else "mdi:message-bulleted"
+        )
+
+        if self.hass is not None:
+            self.schedule_update_ha_state()
+
+    @staticmethod
+    def _normalize_message_code(value: Any) -> str:
+        """Normalize a message code, including numeric JSON values."""
+        code = str(value)
+        if code in MESSAGE_DEFINITIONS:
+            return code
+
+        try:
+            numeric_code = float(code)
+        except (TypeError, ValueError):
+            return code
+
+        return next(
+            (
+                known_code
+                for known_code in MESSAGE_DEFINITIONS
+                if float(known_code) == numeric_code
+            ),
+            code,
+        )
+
+    @staticmethod
+    def _message_details(code: str) -> dict[str, str]:
+        """Return stable metadata for one PoolAccess message code."""
+        definition = MESSAGE_DEFINITIONS.get(code)
+        if definition is None:
+            return {
+                "code": code,
+                "key": f"unknown_{code.replace('.', '_')}",
+                "type": "unknown",
+                "message": f"Unknown Bayrol message ({code})",
+            }
+
+        key, message_type, message = definition
+        return {
+            "code": code,
+            "key": key,
+            "type": message_type,
+            "message": message,
+        }
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the raw codes and decoded messages."""
+        message_keys = [message["key"] for message in self._messages]
+        return {
+            "message_codes": self._message_codes,
+            "message_keys": message_keys,
+            "messages": self._messages,
+            # Compatibility alias for templates migrated from
+            # bayrol-poolaccess-mqtt's MessagesSensor.
+            "data": self._messages,
+        }
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the Bayrol device information."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._config_entry.data[BAYROL_DEVICE_ID])},
             manufacturer="Bayrol",

--- a/custom_components/bayrol/sensor.py
+++ b/custom_components/bayrol/sensor.py
@@ -129,6 +129,77 @@ MESSAGE_DEFINITIONS = {
     "8.36": ("ev_default_reset", "info", "Default reset"),
 }
 
+MESSAGE_TRANSLATIONS = {
+    "fr": {
+        "al_no_flow_bnc": "Pompe de filtration arrêtée (pas de débit)",
+        "al_no_flow_230V": (
+            "Pompe de filtration arrêtée "
+            "(pas de signal 230V~ de la pompe de filtration)"
+        ),
+        "al_start_delay": "Délai de démarrage",
+        "al_se_gas_detected": (
+            "Gaz détecté dans la cellule ; électrolyse de sel arrêtée"
+        ),
+        "al_se_err_setpoint_safe_mode": (
+            "Mesure redox trop basse depuis plusieurs jours ; "
+            "électrolyse en mode Safe"
+        ),
+        "al_se_err_setpoint_stopped": (
+            "Mesure redox trop basse depuis plusieurs jours ; électrolyse arrêtée"
+        ),
+        "al_se_err_setpoint": (
+            "Mesure redox trop basse depuis plusieurs jours"
+        ),
+        "al_se_err_rise_safe_mode": (
+            "La mesure redox n'augmente pas comme prévu ; "
+            "électrolyse en mode Safe"
+        ),
+        "al_se_err_rise_stopped": (
+            "La mesure redox n'augmente pas comme prévu ; électrolyse arrêtée"
+        ),
+        "al_se_err_rise": "La mesure redox n'augmente pas comme prévu",
+        "al_ph_dosing_stopped": (
+            "La mesure pH ne réagit pas comme prévu ; dosage pH arrêté"
+        ),
+        "al_mv_dosing_stopped": (
+            "La mesure redox ne réagit pas comme prévu ; dosage chlore arrêté"
+        ),
+        "al_ph_minus_empty": "Bidon de pH-Minus vide",
+        "al_ph_plus_empty": "Bidon de pH-Plus vide",
+        "al_salt_low_stopped": (
+            "Taux de sel trop bas ; électrolyse arrêtée"
+        ),
+        "al_salt_low_cell_protection": (
+            "Taux de sel trop faible ; production réduite (protection cellule)"
+        ),
+        "al_salt_low_pre_warning": "Taux de sel inférieur au taux préféré",
+        "al_se_production_low": "Production par électrolyse trop faible",
+        "al_ph_too_high": "Mesure pH trop haute",
+        "al_ph_too_low": "Mesure pH trop basse",
+        "al_se_t_low_stopped": (
+            "Température de l'eau trop basse ; électrolyse arrêtée"
+        ),
+        "al_se_t_low_stopped_user": (
+            "Température de l'eau basse ; électrolyse arrêtée"
+        ),
+        "al_se_t_low_cell_protection": (
+            "Température de l'eau trop basse ; "
+            "production réduite (protection cellule)"
+        ),
+        "al_mv_too_high": "Mesure redox trop haute",
+        "al_mv_too_low": "Mesure redox trop basse",
+        "al_se_no_current": "Pas de courant cellule",
+        "al_filtration_short": (
+            "Temps de filtration journalier potentiellement trop faible"
+        ),
+        "al_cl_empty": "Bidon de Chloriliquide vide",
+        "enjoy": "Tout va bien. Profitez de votre piscine !",
+        "ev_sw_reset": "Réinitialisation logicielle",
+        "ev_system_start": "Mise sous tension",
+        "ev_default_reset": "Réinitialisation des paramètres par défaut",
+    }
+}
+
 
 def _handle_sensor_value(sensor, value):
     """Handle incoming sensor value."""
@@ -296,7 +367,7 @@ async def async_setup_entry(
                 entities.append(sensor)
 
     if device_type in ("Automatic SALT", "Automatic Cl-pH"):
-        messages = BayrolMessagesSensor(config_entry)
+        messages = BayrolMessagesSensor(config_entry, hass.config.language)
         mqtt_manager.subscribe(MESSAGE_TOPIC, messages.handle_message_payload)
         entities.append(messages)
 
@@ -349,9 +420,15 @@ class BayrolMessagesSensor(SensorEntity):
     _attr_icon = "mdi:message-bulleted"
     _attr_should_poll = False
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
+    def __init__(self, config_entry: ConfigEntry, language: str) -> None:
         """Initialize the messages sensor."""
         self._config_entry = config_entry
+        self._language = (
+            language.lower().replace("_", "-").split("-", maxsplit=1)[0]
+        )
+        self._message_language = (
+            self._language if self._language in MESSAGE_TRANSLATIONS else "en"
+        )
         self._attr_unique_id = f"{config_entry.entry_id}_{MESSAGE_TOPIC}"
         device_id = normalize_entity_id_part(config_entry.data[BAYROL_DEVICE_ID])
         self.entity_id = f"sensor.bayrol_{device_id}_messages"
@@ -412,8 +489,7 @@ class BayrolMessagesSensor(SensorEntity):
             code,
         )
 
-    @staticmethod
-    def _message_details(code: str) -> dict[str, str]:
+    def _message_details(self, code: str) -> dict[str, str]:
         """Return stable metadata for one PoolAccess message code."""
         definition = MESSAGE_DEFINITIONS.get(code)
         if definition is None:
@@ -421,10 +497,17 @@ class BayrolMessagesSensor(SensorEntity):
                 "code": code,
                 "key": f"unknown_{code.replace('.', '_')}",
                 "type": "unknown",
-                "message": f"Unknown Bayrol message ({code})",
+                "message": (
+                    f"Message Bayrol inconnu ({code})"
+                    if self._message_language == "fr"
+                    else f"Unknown Bayrol message ({code})"
+                ),
             }
 
         key, message_type, message = definition
+        message = MESSAGE_TRANSLATIONS.get(self._message_language, {}).get(
+            key, message
+        )
         return {
             "code": code,
             "key": key,
@@ -439,6 +522,7 @@ class BayrolMessagesSensor(SensorEntity):
         return {
             "message_codes": self._message_codes,
             "message_keys": message_keys,
+            "message_language": self._message_language,
             "messages": self._messages,
             # Compatibility alias for templates migrated from
             # bayrol-poolaccess-mqtt's MessagesSensor.

--- a/custom_components/bayrol/switch.py
+++ b/custom_components/bayrol/switch.py
@@ -1,0 +1,131 @@
+"""Support for Bayrol switch entities."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    BAYROL_DEVICE_ID,
+    BAYROL_DEVICE_TYPE,
+    DOMAIN,
+    SENSOR_TYPES_AUTOMATIC_CL_PH,
+    SENSOR_TYPES_AUTOMATIC_SALT,
+    SENSOR_TYPES_PM5_CHLORINE,
+)
+from .helpers import normalize_entity_id_part
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _switch_definitions(device_type: str) -> dict[str, dict[str, Any]]:
+    """Return entity definitions for the configured device model."""
+    if device_type == "Automatic SALT":
+        return SENSOR_TYPES_AUTOMATIC_SALT
+    if device_type == "Automatic Cl-pH":
+        return SENSOR_TYPES_AUTOMATIC_CL_PH
+    if device_type == "PM5 Chlorine":
+        return SENSOR_TYPES_PM5_CHLORINE
+    return {}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Bayrol switch entities."""
+    mqtt_manager = hass.data[DOMAIN][config_entry.entry_id]["mqtt_manager"]
+    definitions = _switch_definitions(config_entry.data[BAYROL_DEVICE_TYPE])
+    entities = []
+
+    for topic, switch_config in definitions.items():
+        if switch_config.get("entity_type") != "switch":
+            continue
+
+        entity = BayrolSwitch(config_entry, topic, switch_config)
+        mqtt_manager.subscribe(
+            topic, lambda value, switch=entity: switch.handle_mqtt_value(value)
+        )
+        entities.append(entity)
+
+    async_add_entities(entities)
+
+
+class BayrolSwitch(SwitchEntity):
+    """Representation of a writable Bayrol on/off setting."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        topic: str,
+        switch_config: dict[str, Any],
+    ) -> None:
+        """Initialize a Bayrol switch."""
+        self._config_entry = config_entry
+        self._state_topic = topic
+        self._on_value = str(switch_config["on_value"])
+        self._off_value = str(switch_config["off_value"])
+        self._attr_name = switch_config.get("name", topic)
+        self._attr_icon = switch_config.get("icon")
+        self._attr_unique_id = f"{config_entry.entry_id}_{topic}"
+        device_id = normalize_entity_id_part(config_entry.data[BAYROL_DEVICE_ID])
+        name = normalize_entity_id_part(self._attr_name)
+        self.entity_id = f"switch.bayrol_{device_id}_{name}"
+        self._attr_is_on = None
+
+    def handle_mqtt_value(self, value: Any) -> None:
+        """Update the switch from a Bayrol MQTT value."""
+        value = str(value)
+        if value == self._on_value:
+            self._attr_is_on = True
+        elif value == self._off_value:
+            self._attr_is_on = False
+        else:
+            _LOGGER.warning(
+                "Unexpected MQTT value %s for Bayrol switch %s",
+                value,
+                self._state_topic,
+            )
+            return
+
+        if self.hass is not None:
+            self.schedule_update_ha_state()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the Bayrol setting on."""
+        self._publish_value(self._on_value)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the Bayrol setting off."""
+        self._publish_value(self._off_value)
+
+    def _publish_value(self, value: str) -> None:
+        """Publish a setting to the Bayrol MQTT broker."""
+        topic = (
+            f"d02/{self._config_entry.data[BAYROL_DEVICE_ID]}"
+            f"/s/{self._state_topic}"
+        )
+        payload = json.dumps({"t": self._state_topic, "v": float(value)})
+        mqtt_manager = self.hass.data[DOMAIN][self._config_entry.entry_id][
+            "mqtt_manager"
+        ]
+        mqtt_manager.client.publish(topic, payload)
+        _LOGGER.debug("Published MQTT message to %s: %s", topic, payload)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the Bayrol device information."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._config_entry.data[BAYROL_DEVICE_ID])},
+            manufacturer="Bayrol",
+        )


### PR DESCRIPTION
## Summary

This PR add some features and improves MQTT thread handling:

* Add a pH dosing ON/OFF switch using topic `5.42`
* Expose salt electrolysis ON/OFF (`5.40`) as a switch instead of a select
* Add a `Messages` sensor using PoolAccess topic `10`
* Decode all 32 known PoolAccess message codes
* Provide English and French messages based on `hass.config.language`
* Fix concurrent WebSocket writes in Paho MQTT

## Message sensor

The new sensor is available for Automatic SALT and Automatic Cl-pH devices.

It exposes:

* `data`: decoded messages containing the code, stable key, severity and localized text
* `message_codes`: raw Bayrol codes
* `message_keys`: stable keys suitable for automations
* `message_language`: language effectively used

Unknown languages fall back to English. Existing alarm binary sensors using topics `8.2002` and `8.2003` remain unchanged.

## MQTT threading fix

The integration previously ran `loop_forever()` inside a manually created thread. Since this thread was not registered internally by Paho, calls to `publish()` or `subscribe()` from Home Assistant could execute `loop_write()` concurrently with the network loop.

With WebSocket transport, this could raise:

```text
BufferError: Existing exports of data: object cannot be re-sized
```

The MQTT manager now uses Paho's supported threaded interface:

* `connect_async()` and `loop_start()` during startup
* `disconnect()` and `loop_stop()` during unload
* Home Assistant's executor for potentially blocking startup and shutdown operations

## Compatibility note

The existing salt electrolysis select is replaced by a switch. Home Assistant may retain the old select as an unavailable registry entry after upgrading; it can be removed manually once the switch has been verified.

## Validation

* Tested with `paho-mqtt 2.1.0`
* MQTT startup and WebSocket communication tested on an Automatic SALT installation
* French message decoding verified for all 32 known codes
* English fallback and locale normalization verified
* Python compilation and manifest JSON validation completed
