### PR TITLE
Expose Bayrol cover, flow, and gas states as native entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The entities you get depend on the device type you select when adding the integr
 The **MQTT ID** is the topic suffix the device publishes under (see [MQTT Debug](#mqtt-debug)), the **Type** is the Home Assistant platform the entity is created on:
 
 - `sensor` – read only
+- `binary_sensor` – read-only two-state input
+- `cover` – read-only pool-cover state (no controls are exposed)
 - `select` – writable, pick one of a fixed list of values
 - `number` – writable numeric value
 - `switch` – writable on/off setting
@@ -70,13 +72,13 @@ The **MQTT ID** is the topic suffix the device publishes under (see [MQTT Debug]
 | `4.343` | pH Dosed Today ³ | sensor | L |
 | `5.3` | pH Production Rate | select | — |
 | `5.29` | Flow Pump Status | sensor | — |
-| `5.37` | Gas Sensor | sensor | — |
+| `5.37` | Gas Sensor | binary_sensor | — |
 | `5.40` | Salt electrolysis ON/OFF | switch | — |
 | `5.41` | Redox Mode | select | — |
 | `5.42` | pH Dosing ON/OFF | switch | — |
 | `5.80` | pH Minus Canister Status | sensor | — |
-| `5.83` | Cover | sensor | — |
-| `5.98` | Flow Contact | sensor | — |
+| `5.83` | Cover | cover | — |
+| `5.98` | Flow Contact | binary_sensor | — |
 | `5.184` | Filtration mode | select | — |
 | `5.186` | Out 1 Mode | select | — |
 | `5.187` | Out 2 Mode | select | — |
@@ -117,10 +119,10 @@ The **MQTT ID** is the topic suffix the device publishes under (see [MQTT Debug]
 | `5.3` | pH Production Rate | select | — |
 | `5.28` | Flow In Status | sensor | — |
 | `5.29` | Flow Pump Status | sensor | — |
-| `5.37` | Gas Sensor | sensor | — |
+| `5.37` | Gas Sensor | binary_sensor | — |
 | `5.42` | pH Dosing ON/OFF | switch | — |
 | `5.80` | pH Minus Canister Status | sensor | — |
-| `5.83` | Cover | sensor | — |
+| `5.83` | Cover | cover | — |
 | `5.169` | Cl Canister Status | sensor | — |
 | `5.175` | Cl Adjust Dosing Amount | select | % |
 | `5.184` | Filtration mode | select | — |
@@ -280,7 +282,7 @@ The current state of an output is reported by the matching `Out x Status` sensor
 
 When the filter pump is not running, water does not circulate past the probes, so pH, redox and temperature readings become physically stale. The device keeps sending the last measured values anyway - the native Bayrol app shows them the same way, and this integration deliberately mirrors that behavior. Marking those sensors as *unavailable* would also clash with Home Assistant semantics, where *unavailable* means "the data source is broken" (e.g. MQTT connection lost), not "the value is old".
 
-If you prefer gaps in your history instead of stale readings, you can build that per sensor with a standard [template sensor](https://www.home-assistant.io/integrations/template/), using the flow status entity this integration already provides. On Automatic SALT devices this is `Flow Contact` (the paddle switch on the FLOW input), which reports `On` while water is circulating and `Off` otherwise:
+If you prefer gaps in your history instead of stale readings, you can build that per sensor with a standard [template sensor](https://www.home-assistant.io/integrations/template/), using the flow status entity this integration already provides. On Automatic SALT devices this is the `Flow Contact` binary sensor (the paddle switch on the FLOW input), which is `on` while water is circulating and `off` otherwise:
 
 ```yaml
 template:
@@ -288,12 +290,12 @@ template:
       - name: "Pool pH (filtered)"
         unique_id: pool_ph_filtered
         state: >
-          {% if is_state('sensor.bayrol_DEVICEID_flow_contact', 'On') %}
+          {% if is_state('binary_sensor.bayrol_DEVICEID_flow_contact', 'on') %}
             {{ states('sensor.bayrol_DEVICEID_ph') }}
           {% else %}
             unknown
           {% endif %}
-        availability: "{{ has_value('sensor.bayrol_DEVICEID_flow_contact') }}"
+        availability: "{{ has_value('binary_sensor.bayrol_DEVICEID_flow_contact') }}"
 ```
 
 Replace `DEVICEID` with your device id - the exact entity ids are listed under Settings → Devices & Services → Bayrol. On devices without a `Flow Contact` entity, use `Flow Pump Status` instead and check which states it reports (Developer Tools → States). Repeat the pattern for redox and temperature if desired.
@@ -360,5 +362,4 @@ Click the **CONNECT** button and you should see the messages floating in:
 ## Support
 
 If you encounter any issues or have questions, please open an issue on GitHub.
-
 

--- a/custom_components/bayrol/__init__.py
+++ b/custom_components/bayrol/__init__.py
@@ -23,6 +23,7 @@ PLATFORMS = [
     "button",
     "number",
     "binary_sensor",
+    "cover",
     "event",
 ]
 

--- a/custom_components/bayrol/binary_sensor.py
+++ b/custom_components/bayrol/binary_sensor.py
@@ -1,4 +1,4 @@
-"""Binary sensors for Bayrol device alarms.
+"""Binary sensors for Bayrol device states and alarms.
 
 Alarm protocol discovered by @davifernan (PR #33): the device publishes
 dict payloads without a "v" key on topics 8.2002/8.2003.
@@ -21,7 +21,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import (
     ALARM_TOPICS,
     BAYROL_DEVICE_ID,
+    BAYROL_DEVICE_TYPE,
     DOMAIN,
+    SENSOR_TYPES_AUTOMATIC_CL_PH,
+    SENSOR_TYPES_AUTOMATIC_SALT,
+    SENSOR_TYPES_PM5_CHLORINE,
 )
 from .helpers import normalize_entity_id_part
 
@@ -33,10 +37,28 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Bayrol binary sensors (device alarms)."""
+    """Set up the Bayrol binary sensors."""
     mqtt_manager = hass.data[DOMAIN][config_entry.entry_id]["mqtt_manager"]
 
     entities = []
+
+    device_type = config_entry.data[BAYROL_DEVICE_TYPE]
+    sensor_types = {
+        "Automatic SALT": SENSOR_TYPES_AUTOMATIC_SALT,
+        "Automatic Cl-pH": SENSOR_TYPES_AUTOMATIC_CL_PH,
+        "PM5 Chlorine": SENSOR_TYPES_PM5_CHLORINE,
+    }.get(device_type, {})
+
+    for topic, sensor_config in sensor_types.items():
+        if sensor_config.get("entity_type") != "binary_sensor":
+            continue
+
+        sensor = BayrolStateBinarySensor(config_entry, topic, sensor_config)
+        mqtt_manager.subscribe(
+            topic, lambda payload, s=sensor: s.handle_state_payload(payload)
+        )
+        entities.append(sensor)
+
     for topic, alarm_config in ALARM_TOPICS.items():
         sensor = BayrolAlarmBinarySensor(config_entry, topic, alarm_config)
         mqtt_manager.subscribe(
@@ -45,6 +67,65 @@ async def async_setup_entry(
         entities.append(sensor)
 
     async_add_entities(entities)
+
+
+class BayrolStateBinarySensor(BinarySensorEntity):
+    """Binary sensor representing a two-state Bayrol MQTT value."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        topic: str,
+        sensor_config: dict[str, Any],
+    ) -> None:
+        """Initialize the state binary sensor."""
+        self._config_entry = config_entry
+        self._state_topic = topic
+        self._sensor_config = sensor_config
+        self._attr_name = sensor_config.get("name", topic)
+        self._attr_device_class = sensor_config.get("device_class")
+        self._attr_unique_id = f"{config_entry.entry_id}_{topic}"
+        device_id = normalize_entity_id_part(config_entry.data[BAYROL_DEVICE_ID])
+        name = normalize_entity_id_part(sensor_config.get("name", topic))
+        self.entity_id = f"binary_sensor.bayrol_{device_id}_{name}"
+        self._attr_is_on = None
+        self._raw_value: Any = None
+
+    def handle_state_payload(self, payload: Any) -> None:
+        """Process a two-state MQTT payload without guessing unknown values."""
+        self._raw_value = payload
+        value = str(payload)
+
+        if value in self._sensor_config.get("on_values", ()):
+            self._attr_is_on = True
+        elif value in self._sensor_config.get("off_values", ()):
+            self._attr_is_on = False
+        else:
+            self._attr_is_on = None
+            _LOGGER.warning(
+                "Unexpected value %r for binary sensor %s (topic %s)",
+                payload,
+                self._attr_name,
+                self._state_topic,
+            )
+
+        if self.hass is not None:
+            self.schedule_update_ha_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the raw Bayrol value for diagnostics."""
+        return {"raw_value": self._raw_value, "topic": self._state_topic}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._config_entry.data[BAYROL_DEVICE_ID])},
+            manufacturer="Bayrol",
+        )
 
 
 class BayrolAlarmBinarySensor(BinarySensorEntity):

--- a/custom_components/bayrol/const.py
+++ b/custom_components/bayrol/const.py
@@ -1,5 +1,7 @@
 """Constants for the Bayrol integration."""
 
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.cover import CoverDeviceClass
 from homeassistant.components.number import NumberDeviceClass, NumberMode
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -361,11 +363,13 @@ SENSOR_TYPES_AUTOMATIC = {
     },
     "5.37": {
         "name": "Gas Sensor",
-        "device_class": None,
+        "device_class": BinarySensorDeviceClass.GAS,
         "state_class": None,
         "coefficient": None,
         "unit_of_measurement": None,
-        "entity_type": "sensor",
+        "entity_type": "binary_sensor",
+        "on_values": ("19.104",),  # Gas detected
+        "off_values": ("19.105",),  # Water detected
     },
     "5.80": {
         "name": "pH Minus Canister Status",
@@ -377,11 +381,14 @@ SENSOR_TYPES_AUTOMATIC = {
     },
     "5.83": {
         "name": "Cover",
-        "device_class": None,
+        "device_class": CoverDeviceClass.SHUTTER,
         "state_class": None,
         "coefficient": None,
         "unit_of_measurement": None,
-        "entity_type": "sensor",
+        "entity_type": "cover",
+        "open_values": ("19.142",),
+        "closed_values": ("19.143",),
+        "unknown_values": ("19.55",),  # Cover status is disabled
     },
     "5.184": {
         "name": "Filtration mode",
@@ -559,11 +566,13 @@ SENSOR_TYPES_AUTOMATIC_SALT = {
     },
     "5.98": {
         "name": "Flow Contact",
-        "device_class": None,
+        "device_class": BinarySensorDeviceClass.RUNNING,
         "state_class": None,
         "coefficient": None,
         "unit_of_measurement": None,
-        "entity_type": "sensor",
+        "entity_type": "binary_sensor",
+        "on_values": ("19.177",),  # Contact closed: water is flowing
+        "off_values": ("19.176",),  # Contact open: no water flow
     },
 }
 

--- a/custom_components/bayrol/cover.py
+++ b/custom_components/bayrol/cover.py
@@ -1,0 +1,114 @@
+"""Read-only cover entities for Bayrol devices."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    BAYROL_DEVICE_ID,
+    BAYROL_DEVICE_TYPE,
+    DOMAIN,
+    SENSOR_TYPES_AUTOMATIC_CL_PH,
+    SENSOR_TYPES_AUTOMATIC_SALT,
+    SENSOR_TYPES_PM5_CHLORINE,
+)
+from .helpers import normalize_entity_id_part
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up read-only Bayrol covers."""
+    mqtt_manager = hass.data[DOMAIN][config_entry.entry_id]["mqtt_manager"]
+    device_type = config_entry.data[BAYROL_DEVICE_TYPE]
+    sensor_types = {
+        "Automatic SALT": SENSOR_TYPES_AUTOMATIC_SALT,
+        "Automatic Cl-pH": SENSOR_TYPES_AUTOMATIC_CL_PH,
+        "PM5 Chlorine": SENSOR_TYPES_PM5_CHLORINE,
+    }.get(device_type, {})
+
+    entities = []
+    for topic, cover_config in sensor_types.items():
+        if cover_config.get("entity_type") != "cover":
+            continue
+
+        cover = BayrolCover(config_entry, topic, cover_config)
+        mqtt_manager.subscribe(
+            topic, lambda payload, entity=cover: entity.handle_state_payload(payload)
+        )
+        entities.append(cover)
+
+    async_add_entities(entities)
+
+
+class BayrolCover(CoverEntity):
+    """Read-only representation of a Bayrol pool cover state."""
+
+    _attr_should_poll = False
+    _attr_supported_features = CoverEntityFeature(0)
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        topic: str,
+        cover_config: dict[str, Any],
+    ) -> None:
+        """Initialize the cover."""
+        self._config_entry = config_entry
+        self._state_topic = topic
+        self._cover_config = cover_config
+        self._attr_name = cover_config.get("name", topic)
+        self._attr_device_class = cover_config.get("device_class")
+        self._attr_unique_id = f"{config_entry.entry_id}_{topic}"
+        device_id = normalize_entity_id_part(config_entry.data[BAYROL_DEVICE_ID])
+        name = normalize_entity_id_part(cover_config.get("name", topic))
+        self.entity_id = f"cover.bayrol_{device_id}_{name}"
+        self._attr_is_closed = None
+        self._raw_value: Any = None
+
+    def handle_state_payload(self, payload: Any) -> None:
+        """Process a cover state without exposing unsupported controls."""
+        self._raw_value = payload
+        value = str(payload)
+
+        if value in self._cover_config.get("open_values", ()):
+            self._attr_is_closed = False
+        elif value in self._cover_config.get("closed_values", ()):
+            self._attr_is_closed = True
+        elif value in self._cover_config.get("unknown_values", ()):
+            self._attr_is_closed = None
+        else:
+            self._attr_is_closed = None
+            _LOGGER.warning(
+                "Unexpected value %r for cover %s (topic %s)",
+                payload,
+                self._attr_name,
+                self._state_topic,
+            )
+
+        if self.hass is not None:
+            self.schedule_update_ha_state()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the raw Bayrol value for diagnostics."""
+        return {"raw_value": self._raw_value, "topic": self._state_topic}
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._config_entry.data[BAYROL_DEVICE_ID])},
+            manufacturer="Bayrol",
+        )

--- a/custom_components/bayrol/sensor.py
+++ b/custom_components/bayrol/sensor.py
@@ -429,7 +429,9 @@ async def async_setup_entry(
                 "select",
                 "number",
                 "switch",
-            ):  # Skip writable entities
+                "binary_sensor",
+                "cover",
+            ):  # Skip entities exposed by another platform
                 topic = sensor_type
                 sensor = BayrolSensor(config_entry, sensor_type, sensor_config, topic)
                 mqtt_manager.subscribe(
@@ -442,7 +444,9 @@ async def async_setup_entry(
                 "select",
                 "number",
                 "switch",
-            ):  # Skip writable entities
+                "binary_sensor",
+                "cover",
+            ):  # Skip entities exposed by another platform
                 topic = sensor_type
                 sensor = BayrolSensor(config_entry, sensor_type, sensor_config, topic)
                 mqtt_manager.subscribe(
@@ -455,7 +459,9 @@ async def async_setup_entry(
                 "select",
                 "number",
                 "switch",
-            ):  # Skip writable entities
+                "binary_sensor",
+                "cover",
+            ):  # Skip entities exposed by another platform
                 topic = sensor_type
                 sensor = BayrolSensor(config_entry, sensor_type, sensor_config, topic)
                 mqtt_manager.subscribe(


### PR DESCRIPTION
## Summary

* Expose `Cover` (`5.83`) as a read-only Home Assistant `cover` entity
* Expose `Flow Contact` (`5.98`) as a `running` binary sensor
* Expose `Gas Sensor` (`5.37`) as a `gas` binary sensor
* Keep unexpected MQTT values as `unknown` instead of guessing their meaning
* Preserve the raw MQTT value and topic as diagnostic attributes
* Update the entity filtering and README examples

## MQTT mappings

* Cover:
  * `19.142` → open
  * `19.143` → closed
  * `19.55` → unknown/disabled
  
* Flow Contact:
  * `19.177` → on / water flowing
  * `19.176` → off / no flow
  
* Gas Sensor:
  * `19.104` → on / gas detected
  * `19.105` → off / water detected

The cover is intentionally read-only and exposes no open, close, stop, or position controls.

## Compatibility note

This changes the entity domains:

* `sensor.*_cover` → `cover.*_cover`
* `sensor.*_flow_contact` → `binary_sensor.*_flow_contact`
* `sensor.*_gas_sensor` → `binary_sensor.*_gas_sensor`

Existing automations using the previous entity IDs will need to be updated. Home Assistant may also retain the previous sensor registry entries as no longer provided entities.

## Validation

* `git diff --check`
* `python -m compileall -q custom_components/bayrol`
* test en Bayrol AS5
